### PR TITLE
feat: Add Cinder-related tools

### DIFF
--- a/src/openstack_mcp_server/tools/__init__.py
+++ b/src/openstack_mcp_server/tools/__init__.py
@@ -7,6 +7,8 @@ def register_tool(mcp: FastMCP):
     """
     from .glance_tools import GlanceTools
     from .nova_tools import NovaTools
+    from .cinder_tools import CinderTools
 
     NovaTools().register_tools(mcp)
     GlanceTools().register_tools(mcp)
+    CinderTools().register_tools(mcp)

--- a/src/openstack_mcp_server/tools/cinder_tools.py
+++ b/src/openstack_mcp_server/tools/cinder_tools.py
@@ -1,0 +1,33 @@
+from .base import get_openstack_conn
+from fastmcp import FastMCP
+
+
+class CinderTools:
+    """
+    A class to encapsulate Cinder-related tools and utilities.
+    """
+
+    def register_tools(self, mcp: FastMCP):
+        """
+        Register Cinder-related tools with the FastMCP instance.
+        """
+
+        mcp.tool()(self.get_cinder_volumes)
+
+    def get_cinder_volumes(self) -> str:
+        """
+        Get the list of Cinder volumes by invoking the registered tool.
+
+        :return: A string containing the names, IDs, and statuses of the volumes.
+        """
+        # Initialize connection
+        conn = get_openstack_conn()
+
+        # List the volumes
+        volume_list = []
+        for volume in conn.block_storage.volumes():
+            volume_list.append(
+                f"{volume.name} ({volume.id}) - Status: {volume.status}"
+            )
+
+        return "\n".join(volume_list)

--- a/src/openstack_mcp_server/tools/cinder_tools.py
+++ b/src/openstack_mcp_server/tools/cinder_tools.py
@@ -11,8 +11,13 @@ class CinderTools:
         """
         Register Cinder-related tools with the FastMCP instance.
         """
-
         mcp.tool()(self.get_cinder_volumes)
+        mcp.tool()(self.get_volume_details)
+        mcp.tool()(self.create_volume)
+        mcp.tool()(self.delete_volume)
+        mcp.tool()(self.extend_volume)
+        mcp.tool()(self.attach_volume_to_server)
+        mcp.tool()(self.detach_volume_from_server)
 
     def get_cinder_volumes(self) -> str:
         """
@@ -31,3 +36,197 @@ class CinderTools:
             )
 
         return "\n".join(volume_list)
+
+    def get_volume_details(self, volume_id: str) -> str:
+        """
+        Get detailed information about a specific volume.
+
+        :param volume_id: The ID of the volume to get details for
+        :return: A string containing detailed volume information
+        """
+        conn = get_openstack_conn()
+        
+        try:
+            volume = conn.block_storage.get_volume(volume_id)
+            
+            details = [
+                f"Volume Details:",
+                f"  Name: {volume.name or 'N/A'}",
+                f"  ID: {volume.id}",
+                f"  Status: {volume.status}",
+                f"  Size: {volume.size} GB",
+                f"  Volume Type: {volume.volume_type or 'N/A'}",
+                f"  Availability Zone: {volume.availability_zone or 'N/A'}",
+                f"  Created At: {volume.created_at}",
+                f"  Bootable: {volume.is_bootable}",
+                f"  Encrypted: {volume.is_encrypted}",
+                f"  Attachments: {len(volume.attachments)} attachment(s)",
+            ]
+            
+            # Add attachment details if any
+            if volume.attachments:
+                details.append("  Attachment Details:")
+                for attachment in volume.attachments:
+                    details.append(f"    - Server ID: {attachment.get('server_id', 'N/A')}")
+                    details.append(f"      Device: {attachment.get('device', 'N/A')}")
+            
+            return "\n".join(details)
+            
+        except Exception as e:
+            return f"Error retrieving volume details: {str(e)}"
+
+    def create_volume(self, name: str, size: int, description: str = "", 
+                     volume_type: str = "", availability_zone: str = "") -> str:
+        """
+        Create a new volume.
+
+        :param name: Name for the new volume
+        :param size: Size of the volume in GB
+        :param description: Optional description for the volume
+        :param volume_type: Optional volume type
+        :param availability_zone: Optional availability zone
+        :return: A string containing the creation result
+        """
+        conn = get_openstack_conn()
+        
+        try:
+            volume_kwargs = {
+                'name': name,
+                'size': size,
+            }
+            
+            if description:
+                volume_kwargs['description'] = description
+            if volume_type:
+                volume_kwargs['volume_type'] = volume_type
+            if availability_zone:
+                volume_kwargs['availability_zone'] = availability_zone
+            
+            volume = conn.block_storage.create_volume(**volume_kwargs)
+            
+            return (f"Volume creation initiated:\n"
+                   f"  Name: {volume.name}\n"
+                   f"  ID: {volume.id}\n"
+                   f"  Size: {volume.size} GB\n"
+                   f"  Status: {volume.status}")
+                   
+        except Exception as e:
+            return f"Error creating volume: {str(e)}"
+
+    def delete_volume(self, volume_id: str, force: bool = False) -> str:
+        """
+        Delete a volume.
+
+        :param volume_id: The ID of the volume to delete
+        :param force: Whether to force delete the volume
+        :return: A string containing the deletion result
+        """
+        conn = get_openstack_conn()
+        
+        try:
+            # Get volume info before deletion
+            volume = conn.block_storage.get_volume(volume_id)
+            volume_name = volume.name or "Unnamed"
+            
+            # Delete the volume
+            conn.block_storage.delete_volume(volume_id, force=force)
+            
+            return (f"Volume deletion initiated:\n"
+                   f"  Name: {volume_name}\n"
+                   f"  ID: {volume_id}\n"
+                   f"  Force: {force}")
+                   
+        except Exception as e:
+            return f"Error deleting volume: {str(e)}"
+
+    def extend_volume(self, volume_id: str, new_size: int) -> str:
+        """
+        Extend a volume to a new size.
+
+        :param volume_id: The ID of the volume to extend
+        :param new_size: The new size in GB (must be larger than current size)
+        :return: A string containing the extension result
+        """
+        conn = get_openstack_conn()
+        
+        try:
+            # Get current volume info
+            volume = conn.block_storage.get_volume(volume_id)
+            current_size = volume.size
+            
+            if new_size <= current_size:
+                return f"Error: New size ({new_size} GB) must be larger than current size ({current_size} GB)"
+            
+            # Extend the volume
+            conn.block_storage.extend_volume(volume_id, new_size)
+            
+            return (f"Volume extension initiated:\n"
+                   f"  Name: {volume.name or 'Unnamed'}\n"
+                   f"  ID: {volume_id}\n"
+                   f"  Current Size: {current_size} GB\n"
+                   f"  New Size: {new_size} GB")
+                   
+        except Exception as e:
+            return f"Error extending volume: {str(e)}"
+
+    def attach_volume_to_server(self, server_id: str, volume_id: str, device: str = "") -> str:
+        """
+        Attach a volume to a server instance.
+
+        :param server_id: The ID of the server to attach to
+        :param volume_id: The ID of the volume to attach
+        :param device: Optional device name (e.g., /dev/vdb)
+        :return: A string containing the attachment result
+        """
+        conn = get_openstack_conn()
+        
+        try:
+            # Get server and volume info
+            server = conn.compute.get_server(server_id)
+            volume = conn.block_storage.get_volume(volume_id)
+            
+            # Prepare attachment parameters
+            attach_kwargs = {
+                'server': server_id,
+                'volume': volume_id,
+            }
+            
+            if device:
+                attach_kwargs['device'] = device
+            
+            # Attach the volume
+            attachment = conn.compute.create_volume_attachment(**attach_kwargs)
+            
+            return (f"Volume attachment initiated:\n"
+                   f"  Server: {server.name} ({server_id})\n"
+                   f"  Volume: {volume.name or 'Unnamed'} ({volume_id})\n"
+                   f"  Device: {device or 'Auto-assigned'}\n"
+                   f"  Attachment ID: {attachment.id}")
+                   
+        except Exception as e:
+            return f"Error attaching volume: {str(e)}"
+
+    def detach_volume_from_server(self, server_id: str, volume_id: str) -> str:
+        """
+        Detach a volume from a server instance.
+
+        :param server_id: The ID of the server to detach from
+        :param volume_id: The ID of the volume to detach
+        :return: A string containing the detachment result
+        """
+        conn = get_openstack_conn()
+        
+        try:
+            # Get server and volume info
+            server = conn.compute.get_server(server_id)
+            volume = conn.block_storage.get_volume(volume_id)
+            
+            # Detach the volume
+            conn.compute.delete_volume_attachment(volume_id, server_id)
+            
+            return (f"Volume detachment initiated:\n"
+                   f"  Server: {server.name} ({server_id})\n"
+                   f"  Volume: {volume.name or 'Unnamed'} ({volume_id})")
+                   
+        except Exception as e:
+            return f"Error detaching volume: {str(e)}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,18 @@ def mock_get_openstack_conn_glance():
 
 
 @pytest.fixture
+def mock_get_openstack_conn_cinder():
+    """Mock get_openstack_conn function for cinder_tools."""
+    mock_conn = Mock()
+
+    with patch(
+        "openstack_mcp_server.tools.cinder_tools.get_openstack_conn",
+        return_value=mock_conn
+    ) as mock_func:
+        yield mock_conn
+
+
+@pytest.fixture
 def mock_openstack_base():
     """Mock base module functions."""
     mock_conn = Mock()

--- a/tests/tools/test_cinder_tools.py
+++ b/tests/tools/test_cinder_tools.py
@@ -134,6 +134,346 @@ class TestCinderTools:
 
         mock_conn.block_storage.volumes.assert_called_once()
 
+    def test_get_volume_details_success(self, mock_get_openstack_conn_cinder):
+        """Test getting volume details successfully."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        # Create mock volume with detailed info
+        mock_volume = Mock()
+        mock_volume.name = "test-volume"
+        mock_volume.id = "vol-123"
+        mock_volume.status = "available"
+        mock_volume.size = 20
+        mock_volume.volume_type = "ssd"
+        mock_volume.availability_zone = "nova"
+        mock_volume.created_at = "2024-01-01T12:00:00Z"
+        mock_volume.is_bootable = False
+        mock_volume.is_encrypted = True
+        mock_volume.attachments = []
+
+        mock_conn.block_storage.get_volume.return_value = mock_volume
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.get_volume_details("vol-123")
+
+        # Verify key information is present
+        assert "Volume Details:" in result
+        assert "Name: test-volume" in result
+        assert "ID: vol-123" in result
+        assert "Status: available" in result
+        assert "Size: 20 GB" in result
+        assert "Volume Type: ssd" in result
+        assert "Bootable: False" in result
+        assert "Encrypted: True" in result
+
+        mock_conn.block_storage.get_volume.assert_called_once_with("vol-123")
+
+    def test_get_volume_details_with_attachments(self, mock_get_openstack_conn_cinder):
+        """Test getting volume details with attachments."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        # Create mock volume with attachments
+        mock_volume = Mock()
+        mock_volume.name = "attached-volume"
+        mock_volume.id = "vol-attached"
+        mock_volume.status = "in-use"
+        mock_volume.size = 10
+        mock_volume.volume_type = None
+        mock_volume.availability_zone = "nova"
+        mock_volume.created_at = "2024-01-01T12:00:00Z"
+        mock_volume.is_bootable = True
+        mock_volume.is_encrypted = False
+        mock_volume.attachments = [
+            {"server_id": "server-123", "device": "/dev/vdb"},
+            {"server_id": "server-456", "device": "/dev/vdc"}
+        ]
+
+        mock_conn.block_storage.get_volume.return_value = mock_volume
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.get_volume_details("vol-attached")
+
+        assert "Attachments: 2 attachment(s)" in result
+        assert "Attachment Details:" in result
+        assert "Server ID: server-123" in result
+        assert "Device: /dev/vdb" in result
+        assert "Server ID: server-456" in result
+        assert "Device: /dev/vdc" in result
+
+    def test_get_volume_details_error(self, mock_get_openstack_conn_cinder):
+        """Test getting volume details with error."""
+        mock_conn = mock_get_openstack_conn_cinder
+        mock_conn.block_storage.get_volume.side_effect = Exception("Volume not found")
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.get_volume_details("nonexistent-vol")
+
+        assert "Error retrieving volume details: Volume not found" in result
+
+    def test_create_volume_success(self, mock_get_openstack_conn_cinder):
+        """Test creating volume successfully."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        # Mock created volume
+        mock_volume = Mock()
+        mock_volume.name = "new-volume"
+        mock_volume.id = "vol-new-123"
+        mock_volume.size = 10
+        mock_volume.status = "creating"
+
+        mock_conn.block_storage.create_volume.return_value = mock_volume
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.create_volume("new-volume", 10, "Test volume", "ssd", "nova")
+
+        assert "Volume creation initiated:" in result
+        assert "Name: new-volume" in result
+        assert "ID: vol-new-123" in result
+        assert "Size: 10 GB" in result
+        assert "Status: creating" in result
+
+        mock_conn.block_storage.create_volume.assert_called_once_with(
+            name="new-volume",
+            size=10,
+            description="Test volume",
+            volume_type="ssd",
+            availability_zone="nova"
+        )
+
+    def test_create_volume_minimal_params(self, mock_get_openstack_conn_cinder):
+        """Test creating volume with minimal parameters."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        mock_volume = Mock()
+        mock_volume.name = "minimal-volume"
+        mock_volume.id = "vol-minimal"
+        mock_volume.size = 5
+        mock_volume.status = "creating"
+
+        mock_conn.block_storage.create_volume.return_value = mock_volume
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.create_volume("minimal-volume", 5)
+
+        mock_conn.block_storage.create_volume.assert_called_once_with(
+            name="minimal-volume",
+            size=5
+        )
+
+    def test_create_volume_error(self, mock_get_openstack_conn_cinder):
+        """Test creating volume with error."""
+        mock_conn = mock_get_openstack_conn_cinder
+        mock_conn.block_storage.create_volume.side_effect = Exception("Quota exceeded")
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.create_volume("fail-volume", 100)
+
+        assert "Error creating volume: Quota exceeded" in result
+
+    def test_delete_volume_success(self, mock_get_openstack_conn_cinder):
+        """Test deleting volume successfully."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        # Mock volume to be deleted
+        mock_volume = Mock()
+        mock_volume.name = "delete-me"
+        mock_volume.id = "vol-delete"
+
+        mock_conn.block_storage.get_volume.return_value = mock_volume
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.delete_volume("vol-delete", False)
+
+        assert "Volume deletion initiated:" in result
+        assert "Name: delete-me" in result
+        assert "ID: vol-delete" in result
+        assert "Force: False" in result
+
+        mock_conn.block_storage.get_volume.assert_called_once_with("vol-delete")
+        mock_conn.block_storage.delete_volume.assert_called_once_with("vol-delete", force=False)
+
+    def test_delete_volume_force(self, mock_get_openstack_conn_cinder):
+        """Test force deleting volume."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        mock_volume = Mock()
+        mock_volume.name = None  # Test unnamed volume
+        mock_volume.id = "vol-force-delete"
+
+        mock_conn.block_storage.get_volume.return_value = mock_volume
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.delete_volume("vol-force-delete", True)
+
+        assert "Name: Unnamed" in result
+        assert "Force: True" in result
+
+        mock_conn.block_storage.delete_volume.assert_called_once_with("vol-force-delete", force=True)
+
+    def test_delete_volume_error(self, mock_get_openstack_conn_cinder):
+        """Test deleting volume with error."""
+        mock_conn = mock_get_openstack_conn_cinder
+        mock_conn.block_storage.get_volume.side_effect = Exception("Volume not found")
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.delete_volume("nonexistent-vol")
+
+        assert "Error deleting volume: Volume not found" in result
+
+    def test_extend_volume_success(self, mock_get_openstack_conn_cinder):
+        """Test extending volume successfully."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        # Mock current volume
+        mock_volume = Mock()
+        mock_volume.name = "extend-me"
+        mock_volume.id = "vol-extend"
+        mock_volume.size = 10
+
+        mock_conn.block_storage.get_volume.return_value = mock_volume
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.extend_volume("vol-extend", 20)
+
+        assert "Volume extension initiated:" in result
+        assert "Name: extend-me" in result
+        assert "Current Size: 10 GB" in result
+        assert "New Size: 20 GB" in result
+
+        mock_conn.block_storage.get_volume.assert_called_once_with("vol-extend")
+        mock_conn.block_storage.extend_volume.assert_called_once_with("vol-extend", 20)
+
+    def test_extend_volume_invalid_size(self, mock_get_openstack_conn_cinder):
+        """Test extending volume with invalid size."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        mock_volume = Mock()
+        mock_volume.size = 20
+
+        mock_conn.block_storage.get_volume.return_value = mock_volume
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.extend_volume("vol-extend", 15)
+
+        assert "Error: New size (15 GB) must be larger than current size (20 GB)" in result
+        mock_conn.block_storage.extend_volume.assert_not_called()
+
+    def test_extend_volume_error(self, mock_get_openstack_conn_cinder):
+        """Test extending volume with error."""
+        mock_conn = mock_get_openstack_conn_cinder
+        mock_conn.block_storage.get_volume.side_effect = Exception("Volume busy")
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.extend_volume("vol-busy", 30)
+
+        assert "Error extending volume: Volume busy" in result
+
+    def test_attach_volume_success(self, mock_get_openstack_conn_cinder):
+        """Test attaching volume successfully."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        # Mock server and volume
+        mock_server = Mock()
+        mock_server.name = "test-server"
+        mock_server.id = "server-123"
+
+        mock_volume = Mock()
+        mock_volume.name = "attach-vol"
+        mock_volume.id = "vol-attach"
+
+        mock_attachment = Mock()
+        mock_attachment.id = "attachment-123"
+
+        mock_conn.compute.get_server.return_value = mock_server
+        mock_conn.block_storage.get_volume.return_value = mock_volume
+        mock_conn.compute.create_volume_attachment.return_value = mock_attachment
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.attach_volume_to_server("server-123", "vol-attach", "/dev/vdb")
+
+        assert "Volume attachment initiated:" in result
+        assert "Server: test-server (server-123)" in result
+        assert "Volume: attach-vol (vol-attach)" in result
+        assert "Device: /dev/vdb" in result
+        assert "Attachment ID: attachment-123" in result
+
+        mock_conn.compute.create_volume_attachment.assert_called_once_with(
+            server="server-123",
+            volume="vol-attach",
+            device="/dev/vdb"
+        )
+
+    def test_attach_volume_auto_device(self, mock_get_openstack_conn_cinder):
+        """Test attaching volume with auto-assigned device."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        mock_server = Mock()
+        mock_server.name = "auto-server"
+        mock_volume = Mock()
+        mock_volume.name = None  # Test unnamed volume
+        mock_attachment = Mock()
+        mock_attachment.id = "auto-attachment"
+
+        mock_conn.compute.get_server.return_value = mock_server
+        mock_conn.block_storage.get_volume.return_value = mock_volume
+        mock_conn.compute.create_volume_attachment.return_value = mock_attachment
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.attach_volume_to_server("server-123", "vol-attach")
+
+        assert "Volume: Unnamed (vol-attach)" in result
+        assert "Device: Auto-assigned" in result
+
+        mock_conn.compute.create_volume_attachment.assert_called_once_with(
+            server="server-123",
+            volume="vol-attach"
+        )
+
+    def test_attach_volume_error(self, mock_get_openstack_conn_cinder):
+        """Test attaching volume with error."""
+        mock_conn = mock_get_openstack_conn_cinder
+        mock_conn.compute.get_server.side_effect = Exception("Server not found")
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.attach_volume_to_server("nonexistent-server", "vol-attach")
+
+        assert "Error attaching volume: Server not found" in result
+
+    def test_detach_volume_success(self, mock_get_openstack_conn_cinder):
+        """Test detaching volume successfully."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        # Mock server and volume
+        mock_server = Mock()
+        mock_server.name = "detach-server"
+        mock_server.id = "server-456"
+
+        mock_volume = Mock()
+        mock_volume.name = "detach-vol"
+        mock_volume.id = "vol-detach"
+
+        mock_conn.compute.get_server.return_value = mock_server
+        mock_conn.block_storage.get_volume.return_value = mock_volume
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.detach_volume_from_server("server-456", "vol-detach")
+
+        assert "Volume detachment initiated:" in result
+        assert "Server: detach-server (server-456)" in result
+        assert "Volume: detach-vol (vol-detach)" in result
+
+        mock_conn.compute.delete_volume_attachment.assert_called_once_with("vol-detach", "server-456")
+
+    def test_detach_volume_error(self, mock_get_openstack_conn_cinder):
+        """Test detaching volume with error."""
+        mock_conn = mock_get_openstack_conn_cinder
+        mock_conn.compute.get_server.side_effect = Exception("Server not found")
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.detach_volume_from_server("nonexistent-server", "vol-detach")
+
+        assert "Error detaching volume: Server not found" in result
+
     def test_register_tools(self):
         """Test that tools are properly registered with FastMCP."""
         # Create FastMCP mock
@@ -144,11 +484,23 @@ class TestCinderTools:
         cinder_tools = CinderTools()
         cinder_tools.register_tools(mock_mcp)
 
-        # Verify mcp.tool() was called
-        mock_mcp.tool.assert_called_once()
+        # Verify mcp.tool() was called for each method
+        assert mock_mcp.tool.call_count == 7
 
-        # Verify decorator was applied to get_cinder_volumes method
-        mock_tool_decorator.assert_called_once_with(cinder_tools.get_cinder_volumes)
+        # Verify all methods were registered
+        registered_methods = [call[0][0] for call in mock_tool_decorator.call_args_list]
+        expected_methods = [
+            cinder_tools.get_cinder_volumes,
+            cinder_tools.get_volume_details,
+            cinder_tools.create_volume,
+            cinder_tools.delete_volume,
+            cinder_tools.extend_volume,
+            cinder_tools.attach_volume_to_server,
+            cinder_tools.detach_volume_from_server,
+        ]
+
+        for method in expected_methods:
+            assert method in registered_methods
 
     def test_cinder_tools_instantiation(self):
         """Test CinderTools can be instantiated."""
@@ -156,8 +508,22 @@ class TestCinderTools:
         assert cinder_tools is not None
         assert hasattr(cinder_tools, 'register_tools')
         assert hasattr(cinder_tools, 'get_cinder_volumes')
+        assert hasattr(cinder_tools, 'get_volume_details')
+        assert hasattr(cinder_tools, 'create_volume')
+        assert hasattr(cinder_tools, 'delete_volume')
+        assert hasattr(cinder_tools, 'extend_volume')
+        assert hasattr(cinder_tools, 'attach_volume_to_server')
+        assert hasattr(cinder_tools, 'detach_volume_from_server')
+
+        # Verify all methods are callable
         assert callable(cinder_tools.register_tools)
         assert callable(cinder_tools.get_cinder_volumes)
+        assert callable(cinder_tools.get_volume_details)
+        assert callable(cinder_tools.create_volume)
+        assert callable(cinder_tools.delete_volume)
+        assert callable(cinder_tools.extend_volume)
+        assert callable(cinder_tools.attach_volume_to_server)
+        assert callable(cinder_tools.detach_volume_from_server)
 
     def test_get_cinder_volumes_docstring(self):
         """Test that get_cinder_volumes has proper docstring."""
@@ -167,3 +533,23 @@ class TestCinderTools:
         assert docstring is not None
         assert "Get the list of Cinder volumes" in docstring
         assert "return" in docstring.lower() or "Return" in docstring
+
+    def test_all_methods_have_docstrings(self):
+        """Test that all public methods have proper docstrings."""
+        cinder_tools = CinderTools()
+        
+        methods_to_check = [
+            'get_cinder_volumes',
+            'get_volume_details', 
+            'create_volume',
+            'delete_volume',
+            'extend_volume',
+            'attach_volume_to_server',
+            'detach_volume_from_server'
+        ]
+        
+        for method_name in methods_to_check:
+            method = getattr(cinder_tools, method_name)
+            docstring = method.__doc__
+            assert docstring is not None, f"{method_name} should have a docstring"
+            assert len(docstring.strip()) > 0, f"{method_name} docstring should not be empty"

--- a/tests/tools/test_cinder_tools.py
+++ b/tests/tools/test_cinder_tools.py
@@ -1,0 +1,169 @@
+import pytest
+from unittest.mock import Mock
+from openstack_mcp_server.tools.cinder_tools import CinderTools
+
+
+class TestCinderTools:
+    """Test cases for CinderTools class."""
+
+    def test_get_cinder_volumes_success(self, mock_get_openstack_conn_cinder):
+        """Test getting cinder volumes successfully."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        # Create mock volume objects
+        mock_volume1 = Mock()
+        mock_volume1.name = "web-data-volume"
+        mock_volume1.id = "abc123-def456-ghi789"
+        mock_volume1.status = "available"
+
+        mock_volume2 = Mock()
+        mock_volume2.name = "db-backup-volume"
+        mock_volume2.id = "xyz789-uvw456-rst123"
+        mock_volume2.status = "in-use"
+
+        # Configure mock block_storage.volumes()
+        mock_conn.block_storage.volumes.return_value = [mock_volume1, mock_volume2]
+
+        # Test CinderTools
+        cinder_tools = CinderTools()
+        result = cinder_tools.get_cinder_volumes()
+
+        # Verify results
+        expected_output = (
+            "web-data-volume (abc123-def456-ghi789) - Status: available\n"
+            "db-backup-volume (xyz789-uvw456-rst123) - Status: in-use"
+        )
+        assert result == expected_output
+
+        # Verify mock calls
+        mock_conn.block_storage.volumes.assert_called_once()
+
+    def test_get_cinder_volumes_empty_list(self, mock_get_openstack_conn_cinder):
+        """Test getting cinder volumes when no volumes exist."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        # Empty volume list
+        mock_conn.block_storage.volumes.return_value = []
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.get_cinder_volumes()
+
+        # Verify empty string
+        assert result == ""
+
+        mock_conn.block_storage.volumes.assert_called_once()
+
+    def test_get_cinder_volumes_single_volume(self, mock_get_openstack_conn_cinder):
+        """Test getting cinder volumes with a single volume."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        # Single volume
+        mock_volume = Mock()
+        mock_volume.name = "test-volume"
+        mock_volume.id = "single-123"
+        mock_volume.status = "creating"
+
+        mock_conn.block_storage.volumes.return_value = [mock_volume]
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.get_cinder_volumes()
+
+        expected_output = "test-volume (single-123) - Status: creating"
+        assert result == expected_output
+
+        mock_conn.block_storage.volumes.assert_called_once()
+
+    def test_get_cinder_volumes_multiple_statuses(self, mock_get_openstack_conn_cinder):
+        """Test volumes with various statuses."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        # Volumes with different statuses
+        volumes_data = [
+            ("volume-available", "id-1", "available"),
+            ("volume-in-use", "id-2", "in-use"),
+            ("volume-error", "id-3", "error"),
+            ("volume-creating", "id-4", "creating"),
+            ("volume-deleting", "id-5", "deleting"),
+        ]
+
+        mock_volumes = []
+        for name, volume_id, status in volumes_data:
+            mock_volume = Mock()
+            mock_volume.name = name
+            mock_volume.id = volume_id
+            mock_volume.status = status
+            mock_volumes.append(mock_volume)
+
+        mock_conn.block_storage.volumes.return_value = mock_volumes
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.get_cinder_volumes()
+
+        # Verify each volume is included in the result
+        for name, volume_id, status in volumes_data:
+            expected_line = f"{name} ({volume_id}) - Status: {status}"
+            assert expected_line in result
+
+        # Verify line count (5 volumes)
+        assert len(result.split('\n')) == 5
+
+        mock_conn.block_storage.volumes.assert_called_once()
+
+    def test_get_cinder_volumes_with_special_characters(self, mock_get_openstack_conn_cinder):
+        """Test volumes with special characters in names."""
+        mock_conn = mock_get_openstack_conn_cinder
+
+        # Volume names with special characters
+        mock_volume1 = Mock()
+        mock_volume1.name = "web-volume_test-01"
+        mock_volume1.id = "id-with-dashes"
+        mock_volume1.status = "available"
+
+        mock_volume2 = Mock()
+        mock_volume2.name = "db.volume.prod"
+        mock_volume2.id = "id.with.dots"
+        mock_volume2.status = "in-use"
+
+        mock_conn.block_storage.volumes.return_value = [mock_volume1, mock_volume2]
+
+        cinder_tools = CinderTools()
+        result = cinder_tools.get_cinder_volumes()
+
+        assert "web-volume_test-01 (id-with-dashes) - Status: available" in result
+        assert "db.volume.prod (id.with.dots) - Status: in-use" in result
+
+        mock_conn.block_storage.volumes.assert_called_once()
+
+    def test_register_tools(self):
+        """Test that tools are properly registered with FastMCP."""
+        # Create FastMCP mock
+        mock_mcp = Mock()
+        mock_tool_decorator = Mock()
+        mock_mcp.tool.return_value = mock_tool_decorator
+
+        cinder_tools = CinderTools()
+        cinder_tools.register_tools(mock_mcp)
+
+        # Verify mcp.tool() was called
+        mock_mcp.tool.assert_called_once()
+
+        # Verify decorator was applied to get_cinder_volumes method
+        mock_tool_decorator.assert_called_once_with(cinder_tools.get_cinder_volumes)
+
+    def test_cinder_tools_instantiation(self):
+        """Test CinderTools can be instantiated."""
+        cinder_tools = CinderTools()
+        assert cinder_tools is not None
+        assert hasattr(cinder_tools, 'register_tools')
+        assert hasattr(cinder_tools, 'get_cinder_volumes')
+        assert callable(cinder_tools.register_tools)
+        assert callable(cinder_tools.get_cinder_volumes)
+
+    def test_get_cinder_volumes_docstring(self):
+        """Test that get_cinder_volumes has proper docstring."""
+        cinder_tools = CinderTools()
+        docstring = cinder_tools.get_cinder_volumes.__doc__
+
+        assert docstring is not None
+        assert "Get the list of Cinder volumes" in docstring
+        assert "return" in docstring.lower() or "Return" in docstring


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of what this PR does -->
- Create CinderTools baseline code.
- Create CinderTools test baseline code.

## Key Changes
<!-- List the main changes made in this PR -->
- Add Cinder's basic tools(list, get details, create, delete, extend, attach, and detach Cinder volumes)

## Related Issues
<!-- Link to related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->
- #15 

## Additional context
This pull request adds support for managing OpenStack Cinder volumes via new tools and integrates them into the MCP server framework. The main changes include the introduction of a new `CinderTools` class with methods for common volume operations, registration of these tools in the main tool registry, and the addition of a corresponding test fixture for mocking Cinder connections.

**Cinder volume management integration:**

* Added new `CinderTools` class in `src/openstack_mcp_server/tools/cinder_tools.py` with methods to list, get details, create, delete, extend, attach, and detach Cinder volumes, all registered as MCP tools.
* Registered `CinderTools` within the main tool registry in `src/openstack_mcp_server/tools/__init__.py`, enabling its tools to be available through MCP.

**Testing support:**

* Added a pytest fixture `mock_get_openstack_conn_cinder` in `tests/conftest.py` to mock the OpenStack connection for Cinder tool unit tests.
<!-- Any additional information that reviewers should know -->