### PR TITLE
feat: Add region tools

### DIFF
--- a/src/openstack_mcp_server/tools/keystone_tools.py
+++ b/src/openstack_mcp_server/tools/keystone_tools.py
@@ -1,13 +1,6 @@
 from .base import get_openstack_conn
+from .response.keystone import Region
 from fastmcp import FastMCP
-from pydantic import BaseModel
-
-
-# NOTE: In openstacksdk, all of the fields are optional.
-# In this case, we are only using description field as optional.
-class Region(BaseModel):
-    id: str
-    description: str | None = ""
 
 
 class KeystoneTools:

--- a/src/openstack_mcp_server/tools/keystone_tools.py
+++ b/src/openstack_mcp_server/tools/keystone_tools.py
@@ -66,3 +66,18 @@ class KeystoneTools:
         conn.identity.delete_region(region=id, ignore_missing=False)
         
         return f"Region {id} deleted successfully."
+
+    def update_region(self, id: str, description: str = "") -> Region:
+        """
+        Update a region.
+        
+        :param id: The ID of the region. (required)
+        :param description: The string description of the region. It could be None. (optional)
+        
+        :return: The updated Region object.
+        """
+        conn = get_openstack_conn()
+ 
+        updated_region = conn.identity.update_region(region=id, description=description)
+
+        return Region(id=updated_region.id, description=updated_region.description)

--- a/src/openstack_mcp_server/tools/keystone_tools.py
+++ b/src/openstack_mcp_server/tools/keystone_tools.py
@@ -21,6 +21,7 @@ class KeystoneTools:
         """
 
         mcp.tool()(self.get_regions)
+        mcp.tool()(self.get_region)
         mcp.tool()(self.create_region)
         mcp.tool()(self.delete_region)
         mcp.tool()(self.update_region)

--- a/src/openstack_mcp_server/tools/keystone_tools.py
+++ b/src/openstack_mcp_server/tools/keystone_tools.py
@@ -1,12 +1,14 @@
+from .base import get_openstack_conn
 from fastmcp import FastMCP
 from pydantic import BaseModel
-from .base import get_openstack_conn
+
 
 # NOTE: In openstacksdk, all of the fields are optional.
 # In this case, we are only using description field as optional.
 class Region(BaseModel):
     id: str
     description: str | None = ""
+
 
 class KeystoneTools:
     """
@@ -26,24 +28,40 @@ class KeystoneTools:
     def get_regions(self) -> list[Region]:
         """
         Get the list of Keystone regions.
-        
+
         :return: A list of Region objects representing the regions.
         """
         conn = get_openstack_conn()
 
         region_list = []
         for region in conn.identity.regions():
-            region_list.append(Region(id=region.id, description=region.description))
-            
+            region_list.append(
+                Region(id=region.id, description=region.description)
+            )
+
         return region_list
-    
+
+    def get_region(self, id: str) -> Region:
+        """
+        Get a region.
+
+        :param id: The ID of the region. (required)
+
+        :return: The Region object.
+        """
+        conn = get_openstack_conn()
+
+        region = conn.identity.get_region(region=id)
+
+        return Region(id=region.id, description=region.description)
+
     def create_region(self, id: str, description: str = "") -> Region:
         """
         Create a new region.
-        
+
         :param id: The ID of the region. (required)
         :param description: The description of the region. It can be None. (optional)
-        
+
         :return: The created Region object.
         """
         conn = get_openstack_conn()
@@ -51,33 +69,37 @@ class KeystoneTools:
         region = conn.identity.create_region(id=id, description=description)
 
         return Region(id=region.id, description=region.description)
-    
+
     def delete_region(self, id: str) -> None:
         """
         Delete a region.
-        
+
         :param id: The ID of the region. (required)
-        
+
         :return: A message indicating the region was deleted successfully.
         """
         conn = get_openstack_conn()
-        
+
         # ignore_missing is set to False to raise an exception if the region does not exist.
         conn.identity.delete_region(region=id, ignore_missing=False)
-        
+
         return None
 
     def update_region(self, id: str, description: str = "") -> Region:
         """
         Update a region.
-        
+
         :param id: The ID of the region. (required)
         :param description: The string description of the region. It could be None. (optional)
-        
+
         :return: The updated Region object.
         """
         conn = get_openstack_conn()
- 
-        updated_region = conn.identity.update_region(region=id, description=description)
 
-        return Region(id=updated_region.id, description=updated_region.description)
+        updated_region = conn.identity.update_region(
+            region=id, description=description
+        )
+
+        return Region(
+            id=updated_region.id, description=updated_region.description
+        )

--- a/src/openstack_mcp_server/tools/keystone_tools.py
+++ b/src/openstack_mcp_server/tools/keystone_tools.py
@@ -6,7 +6,7 @@ from .base import get_openstack_conn
 # In this case, we are only using description field as optional.
 class Region(BaseModel):
     id: str
-    description: str | None = None
+    description: str | None = ""
 
 class KeystoneTools:
     """
@@ -20,6 +20,8 @@ class KeystoneTools:
 
         mcp.tool()(self.get_regions)
         mcp.tool()(self.create_region)
+        mcp.tool()(self.delete_region)
+        mcp.tool()(self.update_region)
 
     def get_regions(self) -> list[Region]:
         """
@@ -35,12 +37,12 @@ class KeystoneTools:
             
         return region_list
     
-    def create_region(self, id: str, description: str | None = None) -> Region:
+    def create_region(self, id: str, description: str = "") -> Region:
         """
         Create a new region.
         
-        :param id: The ID of the region.
-        :param description: The description of the region. It can be None.
+        :param id: The ID of the region. (required)
+        :param description: The description of the region. It can be None. (optional)
         
         :return: The created Region object.
         """
@@ -50,3 +52,17 @@ class KeystoneTools:
 
         return Region(id=region.id, description=region.description)
     
+    def delete_region(self, id: str) -> str:
+        """
+        Delete a region.
+        
+        :param id: The ID of the region. (required)
+        
+        :return: A message indicating the region was deleted successfully.
+        """
+        conn = get_openstack_conn()
+        
+        # ignore_missing is set to False to raise an exception if the region does not exist.
+        conn.identity.delete_region(region=id, ignore_missing=False)
+        
+        return f"Region {id} deleted successfully."

--- a/src/openstack_mcp_server/tools/keystone_tools.py
+++ b/src/openstack_mcp_server/tools/keystone_tools.py
@@ -54,7 +54,7 @@ class KeystoneTools:
         Create a new region.
 
         :param id: The ID of the region. (required)
-        :param description: The description of the region. It can be None. (optional)
+        :param description: The description of the region. (optional)
 
         :return: The created Region object.
         """
@@ -70,7 +70,7 @@ class KeystoneTools:
 
         :param id: The ID of the region. (required)
 
-        :return: A message indicating the region was deleted successfully.
+        :return: None
         """
         conn = get_openstack_conn()
 
@@ -84,7 +84,7 @@ class KeystoneTools:
         Update a region.
 
         :param id: The ID of the region. (required)
-        :param description: The string description of the region. It could be None. (optional)
+        :param description: The string description of the region. (optional)
 
         :return: The updated Region object.
         """

--- a/src/openstack_mcp_server/tools/keystone_tools.py
+++ b/src/openstack_mcp_server/tools/keystone_tools.py
@@ -52,7 +52,7 @@ class KeystoneTools:
 
         return Region(id=region.id, description=region.description)
     
-    def delete_region(self, id: str) -> str:
+    def delete_region(self, id: str) -> None:
         """
         Delete a region.
         
@@ -65,7 +65,7 @@ class KeystoneTools:
         # ignore_missing is set to False to raise an exception if the region does not exist.
         conn.identity.delete_region(region=id, ignore_missing=False)
         
-        return f"Region {id} deleted successfully."
+        return None
 
     def update_region(self, id: str, description: str = "") -> Region:
         """

--- a/src/openstack_mcp_server/tools/response/keystone.py
+++ b/src/openstack_mcp_server/tools/response/keystone.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+# NOTE: In openstacksdk, all of the fields are optional.
+# In this case, we are only using description field as optional.
+class Region(BaseModel):
+    id: str
+    description: str | None = ""

--- a/src/openstack_mcp_server/tools/response/keystone.py
+++ b/src/openstack_mcp_server/tools/response/keystone.py
@@ -5,4 +5,4 @@ from pydantic import BaseModel
 # In this case, we are only using description field as optional.
 class Region(BaseModel):
     id: str
-    description: str | None = ""
+    description: str = ""

--- a/tests/tools/test_keystone_tools.py
+++ b/tests/tools/test_keystone_tools.py
@@ -209,3 +209,44 @@ class TestKeystoneTools:
         
         # Verify mock calls
         mock_conn.identity.update_region.assert_called_once_with(region=1, description="Region One description")
+    
+    def test_get_region_success(self, mock_get_openstack_conn_keystone):
+        """Test getting a keystone region successfully."""
+        mock_conn = mock_get_openstack_conn_keystone
+
+        # Create mock region object
+        mock_region = Mock()
+        mock_region.id = "RegionOne"
+        mock_region.description = "Region One description"
+        
+        # Configure mock region.get_region()
+        mock_conn.identity.get_region.return_value = mock_region
+
+        # Test get_region()
+        keystone_tools = self.get_keystone_tools()
+        result = keystone_tools.get_region(id="RegionOne")
+        
+        # Verify results
+        assert result == Region(id="RegionOne", description="Region One description")
+        
+        # Verify mock calls
+        mock_conn.identity.get_region.assert_called_once_with(region="RegionOne")
+    
+    def test_get_region_not_found(self, mock_get_openstack_conn_keystone):
+        """Test getting a keystone region that does not exist."""
+        mock_conn = mock_get_openstack_conn_keystone
+
+        # Configure mock to raise NotFoundException
+        mock_conn.identity.get_region.side_effect = exceptions.NotFoundException(
+            "Region 'RegionOne' not found"
+        )
+        
+        # Test get_region()
+        keystone_tools = self.get_keystone_tools()
+        
+        # Verify exception is raised
+        with pytest.raises(exceptions.NotFoundException, match="Region 'RegionOne' not found"):
+            keystone_tools.get_region(id="RegionOne")
+        
+        # Verify mock calls
+        mock_conn.identity.get_region.assert_called_once_with(region="RegionOne")

--- a/tests/tools/test_keystone_tools.py
+++ b/tests/tools/test_keystone_tools.py
@@ -123,7 +123,7 @@ class TestKeystoneTools:
         result = keystone_tools.delete_region(id="RegionOne")
         
         # Verify results
-        assert result == "Region RegionOne deleted successfully."
+        assert result == None
         
         # Verify mock calls
         mock_conn.identity.delete_region.assert_called_once_with(region="RegionOne", ignore_missing=False)

--- a/tests/tools/test_keystone_tools.py
+++ b/tests/tools/test_keystone_tools.py
@@ -113,7 +113,7 @@ class TestKeystoneTools:
 
         # Verify mock calls
         mock_conn.identity.create_region.assert_called_once_with(id=1, description="Region One description") 
-        
+    
     def test_delete_region_success(self, mock_get_openstack_conn_keystone):
         """Test deleting a keystone region successfully."""
         mock_conn = mock_get_openstack_conn_keystone

--- a/tests/tools/test_keystone_tools.py
+++ b/tests/tools/test_keystone_tools.py
@@ -113,4 +113,36 @@ class TestKeystoneTools:
 
         # Verify mock calls
         mock_conn.identity.create_region.assert_called_once_with(id=1, description="Region One description") 
+        
+    def test_delete_region_success(self, mock_get_openstack_conn_keystone):
+        """Test deleting a keystone region successfully."""
+        mock_conn = mock_get_openstack_conn_keystone
+
+        # Test delete_region()
+        keystone_tools = self.get_keystone_tools()
+        result = keystone_tools.delete_region(id="RegionOne")
+        
+        # Verify results
+        assert result == "Region RegionOne deleted successfully."
+        
+        # Verify mock calls
+        mock_conn.identity.delete_region.assert_called_once_with(region="RegionOne", ignore_missing=False)
     
+    def test_delete_region_not_found(self, mock_get_openstack_conn_keystone):
+        """Test deleting a keystone region that does not exist."""
+        mock_conn = mock_get_openstack_conn_keystone
+
+        # Configure mock to raise NotFoundException
+        mock_conn.identity.delete_region.side_effect = exceptions.NotFoundException(
+            "Region 'RegionOne' not found"
+        )
+
+        # Test delete_region()
+        keystone_tools = self.get_keystone_tools()
+        
+        # Verify exception is raised
+        with pytest.raises(exceptions.NotFoundException, match="Region 'RegionOne' not found"):
+            keystone_tools.delete_region(id="RegionOne")
+        
+        # Verify mock calls
+        mock_conn.identity.delete_region.assert_called_once_with(region="RegionOne", ignore_missing=False)


### PR DESCRIPTION
## Overview
- Add Update, delete and get region tool

## Key Changes
<!-- List the main changes made in this PR -->
### Features
- Move `Region` response to /response folder
- Add `get_region` tool
- Add `delete_region` tool
- Add `update_region` tool 
- Add required and optional comments to tool params.

### Testing
- `get_region`, `delete_region`, `update_region` tests have been updated and passed. 

## Related Issues
<!-- Link to related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->
- Closes #14 
- Closes #21 

## Additional context
- In get, delete and update cases, when a specific region does not exist, they raise `NotFoundException`. ([link](https://docs.openstack.org/openstacksdk/latest/user/proxies/identity_v3.html#region-operations)) We have an exception middleware, so I did not handle exceptions manully.
- In `delete_region`, I added `ignore_missing=False` to properly handle error when the region doesn't exist.