### PR TITLE
Remove S101 Ruff Rule in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ python_functions = ["test_*"]
 [tool.ruff]
 line-length = 79
 exclude = [
-    "tests",
     "docs",
 ]
 
@@ -56,6 +55,11 @@ ignore = ["C901", "E501"]
 [tool.ruff.lint.isort]
 lines-after-imports = 2
 no-sections = true
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = [
+    "S101",
+]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/openstack_mcp_server/tools/__init__.py
+++ b/src/openstack_mcp_server/tools/__init__.py
@@ -6,8 +6,8 @@ def register_tool(mcp: FastMCP):
     Register Openstack MCP tools.
     """
     from .glance_tools import GlanceTools
-    from .nova_tools import NovaTools
     from .keystone_tools import KeystoneTools
+    from .nova_tools import NovaTools
 
     NovaTools().register_tools(mcp)
     GlanceTools().register_tools(mcp)

--- a/src/openstack_mcp_server/tools/keystone_tools.py
+++ b/src/openstack_mcp_server/tools/keystone_tools.py
@@ -1,12 +1,14 @@
+from .base import get_openstack_conn
 from fastmcp import FastMCP
 from pydantic import BaseModel
-from .base import get_openstack_conn
+
 
 # NOTE: In openstacksdk, all of the fields are optional.
 # In this case, we are only using description field as optional.
 class Region(BaseModel):
     id: str
     description: str | None = None
+
 
 class KeystoneTools:
     """
@@ -24,24 +26,26 @@ class KeystoneTools:
     def get_regions(self) -> list[Region]:
         """
         Get the list of Keystone regions.
-        
+
         :return: A list of Region objects representing the regions.
         """
         conn = get_openstack_conn()
 
         region_list = []
         for region in conn.identity.regions():
-            region_list.append(Region(id=region.id, description=region.description))
-            
+            region_list.append(
+                Region(id=region.id, description=region.description)
+            )
+
         return region_list
-    
+
     def create_region(self, id: str, description: str | None = None) -> Region:
         """
         Create a new region.
-        
+
         :param id: The ID of the region.
         :param description: The description of the region. It can be None.
-        
+
         :return: The created Region object.
         """
         conn = get_openstack_conn()
@@ -49,4 +53,3 @@ class KeystoneTools:
         region = conn.identity.create_region(id=id, description=description)
 
         return Region(id=region.id, description=region.description)
-    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ def mock_get_openstack_conn():
     with patch(
         "openstack_mcp_server.tools.nova_tools.get_openstack_conn",
         return_value=mock_conn
-    ) as mock_func:
+    ):
         yield mock_conn
 
 
@@ -22,7 +22,7 @@ def mock_get_openstack_conn_glance():
     with patch(
         "openstack_mcp_server.tools.glance_tools.get_openstack_conn",
         return_value=mock_conn
-    ) as mock_func:
+    ):
         yield mock_conn
 
 @pytest.fixture
@@ -33,7 +33,7 @@ def mock_get_openstack_conn_keystone():
     with patch(
         "openstack_mcp_server.tools.keystone_tools.get_openstack_conn",
         return_value=mock_conn
-    ) as mock_func:
+    ):
         yield mock_conn
 
 @pytest.fixture
@@ -44,5 +44,5 @@ def mock_openstack_base():
     with patch(
         "openstack_mcp_server.tools.base.get_openstack_conn",
         return_value=mock_conn
-    ) as mock_func:
+    ):
         yield mock_conn

--- a/tests/tools/test_glance_tools.py
+++ b/tests/tools/test_glance_tools.py
@@ -1,6 +1,5 @@
-import pytest
-from unittest.mock import Mock
 from openstack_mcp_server.tools.glance_tools import GlanceTools
+from unittest.mock import Mock
 
 
 class TestGlanceTools:
@@ -38,7 +37,9 @@ class TestGlanceTools:
         # Verify mock calls
         mock_conn.image.images.assert_called_once()
 
-    def test_get_glance_images_empty_list(self, mock_get_openstack_conn_glance):
+    def test_get_glance_images_empty_list(
+        self, mock_get_openstack_conn_glance
+    ):
         """Test getting glance images when no images exist."""
         mock_conn = mock_get_openstack_conn_glance
 
@@ -53,7 +54,9 @@ class TestGlanceTools:
 
         mock_conn.image.images.assert_called_once()
 
-    def test_get_glance_images_with_empty_name(self, mock_get_openstack_conn_glance):
+    def test_get_glance_images_with_empty_name(
+        self, mock_get_openstack_conn_glance
+    ):
         """Test images with empty or None names."""
         mock_conn = mock_get_openstack_conn_glance
 

--- a/tests/tools/test_keystone_tools.py
+++ b/tests/tools/test_keystone_tools.py
@@ -1,7 +1,8 @@
 import pytest
-from unittest.mock import Mock
 from openstack import exceptions
 from openstack_mcp_server.tools.keystone_tools import KeystoneTools, Region
+from unittest.mock import Mock
+
 
 class TestKeystoneTools:
     """Test cases for KeystoneTools class."""
@@ -9,11 +10,11 @@ class TestKeystoneTools:
     def get_keystone_tools(self) -> KeystoneTools:
         """Get an instance of KeystoneTools."""
         return KeystoneTools()
-    
+
     def test_get_regions_success(self, mock_get_openstack_conn_keystone):
         """Test getting keystone regions successfully."""
         mock_conn = mock_get_openstack_conn_keystone
-        
+
         # Create mock region objects
         mock_region1 = Mock()
         mock_region1.id = "RegionOne"
@@ -22,17 +23,19 @@ class TestKeystoneTools:
         mock_region2 = Mock()
         mock_region2.id = "RegionTwo"
         mock_region2.description = "Region Two description"
-        
+
         # Configure mock region.regions()
         mock_conn.identity.regions.return_value = [mock_region1, mock_region2]
 
         # Test get_regions()
         keystone_tools = self.get_keystone_tools()
         result = keystone_tools.get_regions()
-        
+
         # Verify results
-        assert result == [Region(id="RegionOne", description="Region One description"),
-                          Region(id="RegionTwo", description="Region Two description")]
+        assert result == [
+            Region(id="RegionOne", description="Region One description"),
+            Region(id="RegionTwo", description="Region Two description"),
+        ]
 
         # Verify mock calls
         mock_conn.identity.regions.assert_called_once()
@@ -40,14 +43,14 @@ class TestKeystoneTools:
     def test_get_regions_empty_list(self, mock_get_openstack_conn_keystone):
         """Test getting keystone regions when there are no regions."""
         mock_conn = mock_get_openstack_conn_keystone
-        
+
         # Empty region list
         mock_conn.identity.regions.return_value = []
-        
+
         # Test get_regions()
         keystone_tools = self.get_keystone_tools()
         result = keystone_tools.get_regions()
-        
+
         # Verify results
         assert result == []
 
@@ -57,7 +60,7 @@ class TestKeystoneTools:
     def test_create_region_success(self, mock_get_openstack_conn_keystone):
         """Test creating a keystone region successfully."""
         mock_conn = mock_get_openstack_conn_keystone
-        
+
         # Create mock region object
         mock_region = Mock()
         mock_region.id = "RegionOne"
@@ -68,15 +71,23 @@ class TestKeystoneTools:
 
         # Test create_region()
         keystone_tools = self.get_keystone_tools()
-        result = keystone_tools.create_region(id="RegionOne", description="Region One description")
-        
+        result = keystone_tools.create_region(
+            id="RegionOne", description="Region One description"
+        )
+
         # Verify results
-        assert result == Region(id="RegionOne", description="Region One description")
+        assert result == Region(
+            id="RegionOne", description="Region One description"
+        )
 
         # Verify mock calls
-        mock_conn.identity.create_region.assert_called_once_with(id="RegionOne", description="Region One description")
-    
-    def test_create_region_without_description(self, mock_get_openstack_conn_keystone):
+        mock_conn.identity.create_region.assert_called_once_with(
+            id="RegionOne", description="Region One description"
+        )
+
+    def test_create_region_without_description(
+        self, mock_get_openstack_conn_keystone
+    ):
         """Test creating a keystone region without a description."""
         mock_conn = mock_get_openstack_conn_keystone
 
@@ -95,22 +106,32 @@ class TestKeystoneTools:
         # Verify results
         assert result == Region(id="RegionOne")
 
-    def test_create_region_invalid_id_format(self, mock_get_openstack_conn_keystone):
+    def test_create_region_invalid_id_format(
+        self, mock_get_openstack_conn_keystone
+    ):
         """Test creating a keystone region with an invalid ID format."""
         mock_conn = mock_get_openstack_conn_keystone
 
         # Configure mock region.create_region() to raise an exception
-        mock_conn.identity.create_region.side_effect = exceptions.BadRequestException(
-            "Invalid input for field 'id': Expected string, got integer"
+        mock_conn.identity.create_region.side_effect = (
+            exceptions.BadRequestException(
+                "Invalid input for field 'id': Expected string, got integer"
+            )
         )
 
         # Test create_region()
         keystone_tools = self.get_keystone_tools()
 
         # Verify results
-        with pytest.raises(exceptions.BadRequestException, match="Invalid input for field 'id': Expected string, got integer"):
-            keystone_tools.create_region(id=1, description="Region One description")
+        with pytest.raises(
+            exceptions.BadRequestException,
+            match="Invalid input for field 'id': Expected string, got integer",
+        ):
+            keystone_tools.create_region(
+                id=1, description="Region One description"
+            )
 
         # Verify mock calls
-        mock_conn.identity.create_region.assert_called_once_with(id=1, description="Region One description") 
-    
+        mock_conn.identity.create_region.assert_called_once_with(
+            id=1, description="Region One description"
+        )

--- a/tests/tools/test_nova_tools.py
+++ b/tests/tools/test_nova_tools.py
@@ -1,6 +1,6 @@
-from unittest.mock import Mock, call
-from openstack_mcp_server.tools.response.nova import Server
 from openstack_mcp_server.tools.nova_tools import NovaTools
+from openstack_mcp_server.tools.response.nova import Server
+from unittest.mock import Mock, call
 
 
 class TestNovaTools:
@@ -30,8 +30,16 @@ class TestNovaTools:
 
         # Verify results
         expected_output = [
-            Server(name="web-server-01", id="abc123-def456-ghi789", status="ACTIVE"),
-            Server(name="db-server-01", id="xyz789-uvw456-rst123", status="SHUTOFF"),
+            Server(
+                name="web-server-01",
+                id="abc123-def456-ghi789",
+                status="ACTIVE",
+            ),
+            Server(
+                name="db-server-01",
+                id="xyz789-uvw456-rst123",
+                status="SHUTOFF",
+            ),
         ]
         assert result == expected_output
 
@@ -68,7 +76,9 @@ class TestNovaTools:
         nova_tools = NovaTools()
         result = nova_tools.get_nova_servers()
 
-        expected_output = [Server(name="test-server", id="single-123", status="BUILDING")]
+        expected_output = [
+            Server(name="test-server", id="single-123", status="BUILDING")
+        ]
         assert result == expected_output
 
         mock_conn.compute.servers.assert_called_once()
@@ -102,13 +112,17 @@ class TestNovaTools:
         # Verify each server is included in the result
         for name, server_id, status in servers_data:
             assert any(
-                server.name == name and server.id == server_id and server.status == status
+                server.name == name
+                and server.id == server_id
+                and server.status == status
                 for server in result
             )
 
         mock_conn.compute.servers.assert_called_once()
 
-    def test_get_nova_servers_with_special_characters(self, mock_get_openstack_conn):
+    def test_get_nova_servers_with_special_characters(
+        self, mock_get_openstack_conn
+    ):
         """Test servers with special characters in names."""
         mock_conn = mock_get_openstack_conn
 
@@ -128,9 +142,16 @@ class TestNovaTools:
         nova_tools = NovaTools()
         result = nova_tools.get_nova_servers()
 
-        assert Server(name="web-server_test-01", id="id-with-dashes", status="ACTIVE") in result
-        assert Server(name="db.server.prod", id="id.with.dots", status="SHUTOFF") in result
-
+        assert (
+            Server(
+                name="web-server_test-01", id="id-with-dashes", status="ACTIVE"
+            )
+            in result
+        )
+        assert (
+            Server(name="db.server.prod", id="id.with.dots", status="SHUTOFF")
+            in result
+        )
 
         mock_conn.compute.servers.assert_called_once()
 
@@ -143,19 +164,21 @@ class TestNovaTools:
 
         nova_tools = NovaTools()
         nova_tools.register_tools(mock_mcp)
-        
-        mock_tool_decorator.assert_has_calls([
-            call(nova_tools.get_nova_servers),
-            call(nova_tools.get_nova_server)
-        ])
+
+        mock_tool_decorator.assert_has_calls(
+            [
+                call(nova_tools.get_nova_servers),
+                call(nova_tools.get_nova_server),
+            ]
+        )
         assert mock_tool_decorator.call_count == 2
 
     def test_nova_tools_instantiation(self):
         """Test NovaTools can be instantiated."""
         nova_tools = NovaTools()
         assert nova_tools is not None
-        assert hasattr(nova_tools, 'register_tools')
-        assert hasattr(nova_tools, 'get_nova_servers')
+        assert hasattr(nova_tools, "register_tools")
+        assert hasattr(nova_tools, "get_nova_servers")
         assert callable(nova_tools.register_tools)
         assert callable(nova_tools.get_nova_servers)
 


### PR DESCRIPTION
## Overview (한글)
테스트 코드에 적용되던 Ruff 린팅 규칙을 완화하여 테스트 작성 시 불필요한 제약을 제거했습니다.

## Key Changes (주요 변경사항)
- `pyproject.toml`에서 `tests` 디렉토리를 Ruff 제외 목록에서 제거
- 테스트 파일(`tests/*`)에 대해 `S101` 규칙(assert 사용 금지) 예외 처리 추가
- 테스트 코드 전반에 걸쳐 코드 포맷팅 개선 (import 순서, 줄바꿈, 들여쓰기 등)

## Related Issues (관련 이슈)
- 테스트 코드 작성 시 Ruff 규칙으로 인한 개발 생산성 저하 문제 해결

## Additional context (추가 정보)
테스트 코드에서는 `assert` 문 사용이 필수적이므로 S101 규칙을 예외 처리했습니다. 이를 통해 pytest를 활용한 테스트 작성이 더욱 원활해집니다.

---

## Overview
Relaxed Ruff linting rules for test code to remove unnecessary constraints when writing tests.

## Key Changes
- Removed `tests` directory from Ruff exclusion list in `pyproject.toml`
- Added exception for `S101` rule (assert usage prohibition) for test files (`tests/*`)
- Improved code formatting across test files (import order, line breaks, indentation, etc.)

## Related Issues
- Resolves development productivity issues caused by Ruff rules when writing test code

## Additional context
Since `assert` statements are essential in test code, the S101 rule has been exempted for test files. This enables smoother test development using pytest.