### PR TITLE
feat: Add Cinder-related tools

### DIFF
--- a/src/openstack_mcp_server/tools/__init__.py
+++ b/src/openstack_mcp_server/tools/__init__.py
@@ -10,8 +10,10 @@ def register_tool(mcp: FastMCP):
     from .identity_tools import IdentityTools
     from .image_tools import ImageTools
     from .network_tools import NetworkTools
+    from .block_storage_tools import BlockStorageTools
 
     ComputeTools().register_tools(mcp)
     ImageTools().register_tools(mcp)
     IdentityTools().register_tools(mcp)
     NetworkTools().register_tools(mcp)
+    BlockStorageTools().register_tools(mcp)

--- a/src/openstack_mcp_server/tools/block_storage_tools.py
+++ b/src/openstack_mcp_server/tools/block_storage_tools.py
@@ -1,0 +1,177 @@
+from .response.block_storage import (
+    Volume,
+    VolumeAttachment,
+)
+from .base import get_openstack_conn
+from fastmcp import FastMCP
+
+
+class BlockStorageTools:
+    """
+    A class to encapsulate Block Storage-related tools and utilities.
+    """
+
+    def register_tools(self, mcp: FastMCP):
+        """
+        Register Block Storage-related tools with the FastMCP instance.
+        """
+        mcp.tool()(self.get_block_storage_volumes)
+        mcp.tool()(self.get_volume_details)
+        mcp.tool()(self.create_volume)
+        mcp.tool()(self.delete_volume)
+        mcp.tool()(self.extend_volume)
+
+    def get_block_storage_volumes(self) -> list[Volume]:
+        """
+        Get the list of Block Storage volumes.
+
+        :return: A list of Volume objects representing the volumes.
+        """
+        conn = get_openstack_conn()
+
+        # List the volumes
+        volume_list = []
+        for volume in conn.block_storage.volumes():
+            attachments = []
+            for attachment in volume.attachments or []:
+                attachments.append(
+                    VolumeAttachment(
+                        server_id=attachment.get("server_id"),
+                        device=attachment.get("device"),
+                        attachment_id=attachment.get("id"),
+                    )
+                )
+
+            volume_list.append(
+                Volume(
+                    id=volume.id,
+                    name=volume.name,
+                    status=volume.status,
+                    size=volume.size,
+                    volume_type=volume.volume_type,
+                    availability_zone=volume.availability_zone,
+                    created_at=str(volume.created_at)
+                    if volume.created_at
+                    else None,
+                    is_bootable=volume.is_bootable,
+                    is_encrypted=volume.is_encrypted,
+                    description=volume.description,
+                    attachments=attachments,
+                )
+            )
+
+        return volume_list
+
+    def get_volume_details(self, volume_id: str) -> Volume:
+        """
+        Get detailed information about a specific volume.
+
+        :param volume_id: The ID of the volume to get details for
+        :return: A Volume object with detailed information
+        """
+        conn = get_openstack_conn()
+
+        volume = conn.block_storage.get_volume(volume_id)
+
+        attachments = []
+        for attachment in volume.attachments or []:
+            attachments.append(
+                VolumeAttachment(
+                    server_id=attachment.get("server_id"),
+                    device=attachment.get("device"),
+                    attachment_id=attachment.get("id"),
+                )
+            )
+
+        return Volume(
+            id=volume.id,
+            name=volume.name,
+            status=volume.status,
+            size=volume.size,
+            volume_type=volume.volume_type,
+            availability_zone=volume.availability_zone,
+            created_at=str(volume.created_at),
+            is_bootable=volume.is_bootable,
+            is_encrypted=volume.is_encrypted,
+            description=volume.description,
+            attachments=attachments,
+        )
+
+    def create_volume(
+        self,
+        name: str,
+        size: int,
+        description: str | None = None,
+        volume_type: str | None = None,
+        availability_zone: str | None = None,
+        bootable: bool | None = None,
+        image: str | None = None,
+    ) -> Volume:
+        """
+        Create a new volume.
+
+        :param name: Name for the new volume
+        :param size: Size of the volume in GB
+        :param description: Optional description for the volume
+        :param volume_type: Optional volume type
+        :param availability_zone: Optional availability zone
+        :param bootable: Optional flag to make the volume bootable
+        :param image: Optional Image name, ID or object from which to create
+        :return: The created Volume object
+        """
+        conn = get_openstack_conn()
+
+        volume_kwargs = {
+            "name": name,
+        }
+
+        if description is not None:
+            volume_kwargs["description"] = description
+        if volume_type is not None:
+            volume_kwargs["volume_type"] = volume_type
+        if availability_zone is not None:
+            volume_kwargs["availability_zone"] = availability_zone
+
+        volume = conn.block_storage.create_volume(
+            size=size, image=image, bootable=bootable, **volume_kwargs
+        )
+
+        volume_obj = Volume(
+            id=volume.id,
+            name=volume.name,
+            status=volume.status,
+            size=volume.size,
+            volume_type=volume.volume_type,
+            availability_zone=volume.availability_zone,
+            created_at=str(volume.created_at),
+            is_bootable=volume.is_bootable,
+            is_encrypted=volume.is_encrypted,
+            description=volume.description,
+            attachments=[],
+        )
+
+        return volume_obj
+
+    def delete_volume(self, volume_id: str, force: bool = False) -> None:
+        """
+        Delete a volume.
+
+        :param volume_id: The ID of the volume to delete
+        :param force: Whether to force delete the volume
+        :return: None
+        """
+        conn = get_openstack_conn()
+
+        conn.block_storage.delete_volume(volume_id, force=force, ignore_missing=False)
+
+    def extend_volume(self, volume_id: str, new_size: int) -> None:
+        """
+        Extend a volume to a new size.
+
+        :param volume_id: The ID of the volume to extend
+        :param new_size: The new size in GB (must be larger than current size)
+        :return: None
+        """
+        conn = get_openstack_conn()
+
+        conn.block_storage.extend_volume(volume_id, new_size)

--- a/src/openstack_mcp_server/tools/block_storage_tools.py
+++ b/src/openstack_mcp_server/tools/block_storage_tools.py
@@ -15,13 +15,13 @@ class BlockStorageTools:
         """
         Register Block Storage-related tools with the FastMCP instance.
         """
-        mcp.tool()(self.get_block_storage_volumes)
+        mcp.tool()(self.get_volumes)
         mcp.tool()(self.get_volume_details)
         mcp.tool()(self.create_volume)
         mcp.tool()(self.delete_volume)
         mcp.tool()(self.extend_volume)
 
-    def get_block_storage_volumes(self) -> list[Volume]:
+    def get_volumes(self) -> list[Volume]:
         """
         Get the list of Block Storage volumes.
 

--- a/src/openstack_mcp_server/tools/response/block_storage.py
+++ b/src/openstack_mcp_server/tools/response/block_storage.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel
+
+
+class VolumeAttachment(BaseModel):
+    server_id: str | None = None
+    device: str | None = None
+    attachment_id: str | None = None
+
+
+class Volume(BaseModel):
+    id: str
+    name: str | None = None
+    status: str
+    size: int
+    volume_type: str | None = None
+    availability_zone: str | None = None
+    created_at: str
+    is_bootable: bool | None = None
+    is_encrypted: bool | None = None
+    description: str | None = None
+    attachments: list[VolumeAttachment] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,3 +61,14 @@ def mock_openstack_connect_network():
         return_value=mock_conn,
     ):
         yield mock_conn
+
+@pytest.fixture
+def mock_get_openstack_conn_block_storage():
+    """Mock get_openstack_conn function for block_storage_tools."""
+    mock_conn = Mock()
+
+    with patch(
+        "openstack_mcp_server.tools.block_storage_tools.get_openstack_conn",
+        return_value=mock_conn,
+    ):
+        yield mock_conn

--- a/tests/tools/test_block_storage_tools.py
+++ b/tests/tools/test_block_storage_tools.py
@@ -1,0 +1,646 @@
+import pytest
+from openstack_mcp_server.tools.block_storage_tools import BlockStorageTools
+from openstack_mcp_server.tools.response.block_storage import (
+    Volume,
+    VolumeAttachment,
+)
+
+from unittest.mock import Mock
+
+class TestBlockStorageTools:
+    """Test cases for BlockStorageTools class."""
+
+    def test_get_block_storage_volumes_success(self, mock_get_openstack_conn_block_storage):
+        """Test getting block storage volumes successfully."""
+        mock_conn = mock_get_openstack_conn_block_storage
+
+        # Create mock volume objects
+        mock_volume1 = Mock()
+        mock_volume1.name = "web-data-volume"
+        mock_volume1.id = "abc123-def456-ghi789"
+        mock_volume1.status = "available"
+        mock_volume1.size = 10
+        mock_volume1.volume_type = "ssd"
+        mock_volume1.availability_zone = "nova"
+        mock_volume1.created_at = "2024-01-01T12:00:00Z"
+        mock_volume1.is_bootable = False
+        mock_volume1.is_encrypted = False
+        mock_volume1.description = "Web data volume"
+        mock_volume1.attachments = []
+
+        mock_volume2 = Mock()
+        mock_volume2.name = "db-backup-volume"
+        mock_volume2.id = "xyz789-uvw456-rst123"
+        mock_volume2.status = "in-use"
+        mock_volume2.size = 20
+        mock_volume2.volume_type = "hdd"
+        mock_volume2.availability_zone = "nova"
+        mock_volume2.created_at = "2024-01-02T12:00:00Z"
+        mock_volume2.is_bootable = True
+        mock_volume2.is_encrypted = True
+        mock_volume2.description = "DB backup volume"
+        mock_volume2.attachments = []
+
+        # Configure mock block_storage.volumes()
+        mock_conn.block_storage.volumes.return_value = [
+            mock_volume1,
+            mock_volume2,
+        ]
+
+        # Test BlockStorageTools
+        block_storage_tools = BlockStorageTools()
+        result = block_storage_tools.get_block_storage_volumes()
+
+        # Verify results
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert all(isinstance(vol, Volume) for vol in result)
+
+        # Check first volume
+        vol1 = result[0]
+        assert vol1.id == "abc123-def456-ghi789"
+        assert vol1.name == "web-data-volume"
+        assert vol1.status == "available"
+        assert vol1.size == 10
+
+        # Check second volume
+        vol2 = result[1]
+        assert vol2.id == "xyz789-uvw456-rst123"
+        assert vol2.name == "db-backup-volume"
+        assert vol2.status == "in-use"
+        assert vol2.size == 20
+
+        # Verify mock calls
+        mock_conn.block_storage.volumes.assert_called_once()
+
+    def test_get_block_storage_volumes_empty_list(
+        self, mock_get_openstack_conn_block_storage
+    ):
+        """Test getting block storage volumes when no volumes exist."""
+        mock_conn = mock_get_openstack_conn_block_storage
+
+        # Empty volume list
+        mock_conn.block_storage.volumes.return_value = []
+
+        block_storage_tools = BlockStorageTools()
+        result = block_storage_tools.get_block_storage_volumes()
+
+        # Verify empty list
+        assert isinstance(result, list)
+        assert len(result) == 0
+
+        mock_conn.block_storage.volumes.assert_called_once()
+
+    def test_get_block_storage_volumes_single_volume(
+        self, mock_get_openstack_conn_block_storage
+    ):
+        """Test getting block storage volumes with a single volume."""
+        mock_conn = mock_get_openstack_conn_block_storage
+
+        # Single volume
+        mock_volume = Mock()
+        mock_volume.name = "test-volume"
+        mock_volume.id = "single-123"
+        mock_volume.status = "creating"
+        mock_volume.size = 5
+        mock_volume.volume_type = None
+        mock_volume.availability_zone = "nova"
+        mock_volume.created_at = None
+        mock_volume.is_bootable = False
+        mock_volume.is_encrypted = False
+        mock_volume.description = None
+        mock_volume.attachments = []
+
+        mock_conn.block_storage.volumes.return_value = [mock_volume]
+
+        block_storage_tools = BlockStorageTools()
+        result = block_storage_tools.get_block_storage_volumes()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0].name == "test-volume"
+        assert result[0].id == "single-123"
+        assert result[0].status == "creating"
+
+        mock_conn.block_storage.volumes.assert_called_once()
+
+    def test_get_block_storage_volumes_multiple_statuses(
+        self, mock_get_openstack_conn_block_storage
+    ):
+        """Test volumes with various statuses."""
+        mock_conn = mock_get_openstack_conn_block_storage
+
+        # Volumes with different statuses
+        volumes_data = [
+            ("volume-available", "id-1", "available"),
+            ("volume-in-use", "id-2", "in-use"),
+            ("volume-error", "id-3", "error"),
+            ("volume-creating", "id-4", "creating"),
+            ("volume-deleting", "id-5", "deleting"),
+        ]
+
+        mock_volumes = []
+        for name, volume_id, status in volumes_data:
+            mock_volume = Mock()
+            mock_volume.name = name
+            mock_volume.id = volume_id
+            mock_volume.status = status
+            mock_volume.size = 10
+            mock_volume.volume_type = "standard"
+            mock_volume.availability_zone = "nova"
+            mock_volume.created_at = "2024-01-01T12:00:00Z"
+            mock_volume.is_bootable = False
+            mock_volume.is_encrypted = False
+            mock_volume.description = f"Description for {name}"
+            mock_volume.attachments = []
+            mock_volumes.append(mock_volume)
+
+        mock_conn.block_storage.volumes.return_value = mock_volumes
+
+        block_storage_tools = BlockStorageTools()
+        result = block_storage_tools.get_block_storage_volumes()
+
+        # Verify result is a list with correct length
+        assert isinstance(result, list)
+        assert len(result) == 5
+
+        # Verify each volume is included in the result
+        result_by_id = {vol.id: vol for vol in result}
+        for name, volume_id, status in volumes_data:
+            assert volume_id in result_by_id
+            vol = result_by_id[volume_id]
+            assert vol.name == name
+            assert vol.status == status
+
+        mock_conn.block_storage.volumes.assert_called_once()
+
+    def test_get_block_storage_volumes_with_special_characters(
+        self, mock_get_openstack_conn_block_storage
+    ):
+        """Test volumes with special characters in names."""
+        mock_conn = mock_get_openstack_conn_block_storage
+
+        # Volume names with special characters
+        mock_volume1 = Mock()
+        mock_volume1.name = "web-volume_test-01"
+        mock_volume1.id = "id-with-dashes"
+        mock_volume1.status = "available"
+        mock_volume1.size = 15
+        mock_volume1.volume_type = "ssd"
+        mock_volume1.availability_zone = "nova"
+        mock_volume1.created_at = "2024-01-01T12:00:00Z"
+        mock_volume1.is_bootable = False
+        mock_volume1.is_encrypted = False
+        mock_volume1.description = None
+        mock_volume1.attachments = []
+
+        mock_volume2 = Mock()
+        mock_volume2.name = "db.volume.prod"
+        mock_volume2.id = "id.with.dots"
+        mock_volume2.status = "in-use"
+        mock_volume2.size = 25
+        mock_volume2.volume_type = "hdd"
+        mock_volume2.availability_zone = "nova"
+        mock_volume2.created_at = "2024-01-02T12:00:00Z"
+        mock_volume2.is_bootable = True
+        mock_volume2.is_encrypted = True
+        mock_volume2.description = "Production DB volume"
+        mock_volume2.attachments = []
+
+        mock_conn.block_storage.volumes.return_value = [
+            mock_volume1,
+            mock_volume2,
+        ]
+
+        block_storage_tools = BlockStorageTools()
+        result = block_storage_tools.get_block_storage_volumes()
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+        # Find volumes by name
+        vol1 = next(vol for vol in result if vol.name == "web-volume_test-01")
+        vol2 = next(vol for vol in result if vol.name == "db.volume.prod")
+
+        assert vol1.id == "id-with-dashes"
+        assert vol1.status == "available"
+        assert vol2.id == "id.with.dots"
+        assert vol2.status == "in-use"
+
+        mock_conn.block_storage.volumes.assert_called_once()
+
+    def test_get_volume_details_success(self, mock_get_openstack_conn_block_storage):
+        """Test getting volume details successfully."""
+        mock_conn = mock_get_openstack_conn_block_storage
+
+        # Create mock volume with detailed info
+        mock_volume = Mock()
+        mock_volume.name = "test-volume"
+        mock_volume.id = "vol-123"
+        mock_volume.status = "available"
+        mock_volume.size = 20
+        mock_volume.volume_type = "ssd"
+        mock_volume.availability_zone = "nova"
+        mock_volume.created_at = "2024-01-01T12:00:00Z"
+        mock_volume.is_bootable = False
+        mock_volume.is_encrypted = True
+        mock_volume.description = "Test volume description"
+        mock_volume.attachments = []
+
+        mock_conn.block_storage.get_volume.return_value = mock_volume
+
+        block_storage_tools = BlockStorageTools()
+        result = block_storage_tools.get_volume_details("vol-123")
+
+        # Verify result is a Volume object
+        assert isinstance(result, Volume)
+        assert result.name == "test-volume"
+        assert result.id == "vol-123"
+        assert result.status == "available"
+        assert result.size == 20
+        assert result.volume_type == "ssd"
+        assert result.availability_zone == "nova"
+        assert not result.is_bootable
+        assert result.is_encrypted
+        assert result.description == "Test volume description"
+        assert len(result.attachments) == 0
+
+        mock_conn.block_storage.get_volume.assert_called_once_with("vol-123")
+
+    def test_get_volume_details_with_attachments(
+        self, mock_get_openstack_conn_block_storage
+    ):
+        """Test getting volume details with attachments."""
+        mock_conn = mock_get_openstack_conn_block_storage
+
+        # Create mock volume with attachments
+        mock_volume = Mock()
+        mock_volume.name = "attached-volume"
+        mock_volume.id = "vol-attached"
+        mock_volume.status = "in-use"
+        mock_volume.size = 10
+        mock_volume.volume_type = None
+        mock_volume.availability_zone = "nova"
+        mock_volume.created_at = "2024-01-01T12:00:00Z"
+        mock_volume.is_bootable = True
+        mock_volume.is_encrypted = False
+        mock_volume.description = "Attached volume"
+        mock_volume.attachments = [
+            {
+                "server_id": "server-123",
+                "device": "/dev/vdb",
+                "id": "attach-1",
+            },
+            {
+                "server_id": "server-456",
+                "device": "/dev/vdc",
+                "id": "attach-2",
+            },
+        ]
+
+        mock_conn.block_storage.get_volume.return_value = mock_volume
+
+        block_storage_tools = BlockStorageTools()
+        result = block_storage_tools.get_volume_details("vol-attached")
+
+        # Verify result is a Volume object
+        assert isinstance(result, Volume)
+        assert result.name == "attached-volume"
+        assert result.status == "in-use"
+        assert len(result.attachments) == 2
+
+        # Verify attachment details
+        attach1 = result.attachments[0]
+        attach2 = result.attachments[1]
+
+        assert isinstance(attach1, VolumeAttachment)
+        assert attach1.server_id == "server-123"
+        assert attach1.device == "/dev/vdb"
+        assert attach1.attachment_id == "attach-1"
+
+        assert isinstance(attach2, VolumeAttachment)
+        assert attach2.server_id == "server-456"
+        assert attach2.device == "/dev/vdc"
+        assert attach2.attachment_id == "attach-2"
+
+    def test_get_volume_details_error(self, mock_get_openstack_conn_block_storage):
+        """Test getting volume details with error."""
+        mock_conn = mock_get_openstack_conn_block_storage
+        mock_conn.block_storage.get_volume.side_effect = Exception(
+            "Volume not found"
+        )
+
+        block_storage_tools = BlockStorageTools()
+
+        # Should raise exception directly
+        with pytest.raises(Exception, match="Volume not found"):
+            block_storage_tools.get_volume_details("nonexistent-vol")
+
+    def test_create_volume_success(self, mock_get_openstack_conn_block_storage):
+        """Test creating volume successfully."""
+        mock_conn = mock_get_openstack_conn_block_storage
+
+        # Mock created volume
+        mock_volume = Mock()
+        mock_volume.name = "new-volume"
+        mock_volume.id = "vol-new-123"
+        mock_volume.size = 10
+        mock_volume.status = "creating"
+        mock_volume.volume_type = "ssd"
+        mock_volume.availability_zone = "nova"
+        mock_volume.created_at = "2024-01-01T12:00:00Z"
+        mock_volume.is_bootable = False
+        mock_volume.is_encrypted = False
+        mock_volume.description = "Test volume"
+        mock_volume.attachments = []
+
+        mock_conn.block_storage.create_volume.return_value = mock_volume
+
+        block_storage_tools = BlockStorageTools()
+        result = block_storage_tools.create_volume(
+            "new-volume", 10, "Test volume", "ssd", "nova"
+        )
+
+        # Verify result is a Volume object
+        assert isinstance(result, Volume)
+        assert result.name == "new-volume"
+        assert result.id == "vol-new-123"
+        assert result.size == 10
+        assert result.status == "creating"
+        assert result.volume_type == "ssd"
+        assert result.availability_zone == "nova"
+
+        mock_conn.block_storage.create_volume.assert_called_once_with(
+            size=10,
+            image=None,
+            bootable=None,
+            name="new-volume",
+            description="Test volume",
+            volume_type="ssd",
+            availability_zone="nova",
+        )
+
+    def test_create_volume_minimal_params(
+        self, mock_get_openstack_conn_block_storage
+    ):
+        """Test creating volume with minimal parameters."""
+        mock_conn = mock_get_openstack_conn_block_storage
+
+        mock_volume = Mock()
+        mock_volume.name = "minimal-volume"
+        mock_volume.id = "vol-minimal"
+        mock_volume.size = 5
+        mock_volume.status = "creating"
+        mock_volume.volume_type = None
+        mock_volume.availability_zone = None
+        mock_volume.created_at = "2024-01-01T12:00:00Z"
+        mock_volume.is_bootable = False
+        mock_volume.is_encrypted = False
+        mock_volume.description = None
+        mock_volume.attachments = []
+
+        mock_conn.block_storage.create_volume.return_value = mock_volume
+
+        block_storage_tools = BlockStorageTools()
+        result = block_storage_tools.create_volume("minimal-volume", 5)
+
+        # Verify result structure
+        assert isinstance(result, Volume)
+        assert result.name == "minimal-volume"
+        assert result.size == 5
+
+        mock_conn.block_storage.create_volume.assert_called_once_with(
+            size=5, image=None, bootable=None, name="minimal-volume"
+        )
+
+    def test_create_volume_with_image_and_bootable(
+        self, mock_get_openstack_conn_block_storage
+    ):
+        """Test creating volume with image and bootable parameters."""
+        mock_conn = mock_get_openstack_conn_block_storage
+
+        mock_volume = Mock()
+        mock_volume.name = "bootable-volume"
+        mock_volume.id = "vol-bootable"
+        mock_volume.size = 20
+        mock_volume.status = "creating"
+        mock_volume.volume_type = "ssd"
+        mock_volume.availability_zone = "nova"
+        mock_volume.created_at = "2024-01-01T12:00:00Z"
+        mock_volume.is_bootable = True
+        mock_volume.is_encrypted = False
+        mock_volume.description = "Bootable volume from image"
+        mock_volume.attachments = []
+
+        mock_conn.block_storage.create_volume.return_value = mock_volume
+
+        block_storage_tools = BlockStorageTools()
+        result = block_storage_tools.create_volume(
+            "bootable-volume",
+            20,
+            "Bootable volume from image",
+            "ssd",
+            "nova",
+            True,
+            "ubuntu-20.04",
+        )
+
+        assert isinstance(result, Volume)
+        assert result.name == "bootable-volume"
+        assert result.id == "vol-bootable"
+        assert result.size == 20
+        assert result.is_bootable
+
+        mock_conn.block_storage.create_volume.assert_called_once_with(
+            size=20,
+            image="ubuntu-20.04",
+            bootable=True,
+            name="bootable-volume",
+            description="Bootable volume from image",
+            volume_type="ssd",
+            availability_zone="nova",
+        )
+
+    def test_create_volume_error(self, mock_get_openstack_conn_block_storage):
+        """Test creating volume with error."""
+        mock_conn = mock_get_openstack_conn_block_storage
+        mock_conn.block_storage.create_volume.side_effect = Exception(
+            "Quota exceeded"
+        )
+
+        block_storage_tools = BlockStorageTools()
+
+        with pytest.raises(Exception, match="Quota exceeded"):
+            block_storage_tools.create_volume("fail-volume", 100)
+
+    def test_delete_volume_success(self, mock_get_openstack_conn_block_storage):
+        """Test deleting volume successfully."""
+        mock_conn = mock_get_openstack_conn_block_storage
+
+        # Mock volume to be deleted
+        mock_volume = Mock()
+        mock_volume.name = "delete-me"
+        mock_volume.id = "vol-delete"
+
+        mock_conn.block_storage.get_volume.return_value = mock_volume
+
+        block_storage_tools = BlockStorageTools()
+        result = block_storage_tools.delete_volume("vol-delete", False)
+
+        # Verify result is None
+        assert result is None
+        mock_conn.block_storage.delete_volume.assert_called_once_with(
+            "vol-delete", force=False
+        )
+
+    def test_delete_volume_force(self, mock_get_openstack_conn_block_storage):
+        """Test force deleting volume."""
+        mock_conn = mock_get_openstack_conn_block_storage
+
+        mock_volume = Mock()
+        mock_volume.name = None  # Test unnamed volume
+        mock_volume.id = "vol-force-delete"
+
+        mock_conn.block_storage.get_volume.return_value = mock_volume
+
+        block_storage_tools = BlockStorageTools()
+        result = block_storage_tools.delete_volume("vol-force-delete", True)
+
+        # Verify result is None
+        assert result is None
+
+        mock_conn.block_storage.delete_volume.assert_called_once_with(
+            "vol-force-delete", force=True
+        )
+
+    def test_delete_volume_error(self, mock_get_openstack_conn_block_storage):
+        """Test deleting volume with error."""
+        mock_conn = mock_get_openstack_conn_block_storage
+        mock_conn.block_storage.delete_volume.side_effect = Exception(
+            "Volume not found"
+        )
+
+        block_storage_tools = BlockStorageTools()
+
+        # Should raise exception directly
+        with pytest.raises(Exception, match="Volume not found"):
+            block_storage_tools.delete_volume("nonexistent-vol")
+
+    def test_extend_volume_success(self, mock_get_openstack_conn_block_storage):
+        """Test extending volume successfully."""
+        mock_conn = mock_get_openstack_conn_block_storage
+
+        block_storage_tools = BlockStorageTools()
+        result = block_storage_tools.extend_volume("vol-extend", 20)
+
+        # Verify result is None
+        assert result is None
+
+        mock_conn.block_storage.extend_volume.assert_called_once_with(
+            "vol-extend", 20
+        )
+
+    def test_extend_volume_invalid_size(self, mock_get_openstack_conn_block_storage):
+        """Test extending volume with invalid size."""
+        mock_conn = mock_get_openstack_conn_block_storage
+        mock_conn.block_storage.extend_volume.side_effect = Exception(
+            "Invalid size"
+        )
+
+        block_storage_tools = BlockStorageTools()
+
+        with pytest.raises(Exception, match="Invalid size"):
+            block_storage_tools.extend_volume("vol-extend", 15)
+
+    def test_extend_volume_error(self, mock_get_openstack_conn_block_storage):
+        """Test extending volume with error."""
+        mock_conn = mock_get_openstack_conn_block_storage
+        mock_conn.block_storage.extend_volume.side_effect = Exception(
+            "Volume busy"
+        )
+
+        block_storage_tools = BlockStorageTools()
+
+        with pytest.raises(Exception, match="Volume busy"):
+            block_storage_tools.extend_volume("vol-busy", 30)
+
+    def test_register_tools(self):
+        """Test that tools are properly registered with FastMCP."""
+        # Create FastMCP mock
+        mock_mcp = Mock()
+        mock_tool_decorator = Mock()
+        mock_mcp.tool.return_value = mock_tool_decorator
+
+        block_storage_tools = BlockStorageTools()
+        block_storage_tools.register_tools(mock_mcp)
+
+        # Verify mcp.tool() was called for each method
+        assert mock_mcp.tool.call_count == 5
+
+        # Verify all methods were registered
+        registered_methods = [
+            call[0][0] for call in mock_tool_decorator.call_args_list
+        ]
+        expected_methods = [
+            block_storage_tools.get_block_storage_volumes,
+            block_storage_tools.get_volume_details,
+            block_storage_tools.create_volume,
+            block_storage_tools.delete_volume,
+            block_storage_tools.extend_volume,
+        ]
+
+        for method in expected_methods:
+            assert method in registered_methods
+
+    def test_block_storage_tools_instantiation(self):
+        """Test BlockStorageTools can be instantiated."""
+        block_storage_tools = BlockStorageTools()
+        assert block_storage_tools is not None
+        assert hasattr(block_storage_tools, "register_tools")
+        assert hasattr(block_storage_tools, "get_block_storage_volumes")
+        assert hasattr(block_storage_tools, "get_volume_details")
+        assert hasattr(block_storage_tools, "create_volume")
+        assert hasattr(block_storage_tools, "delete_volume")
+        assert hasattr(block_storage_tools, "extend_volume")
+        # Verify all methods are callable
+        assert callable(block_storage_tools.register_tools)
+        assert callable(block_storage_tools.get_block_storage_volumes)
+        assert callable(block_storage_tools.get_volume_details)
+        assert callable(block_storage_tools.create_volume)
+        assert callable(block_storage_tools.delete_volume)
+        assert callable(block_storage_tools.extend_volume)
+
+    def test_get_block_storage_volumes_docstring(self):
+        """Test that get_block_storage_volumes has proper docstring."""
+        block_storage_tools = BlockStorageTools()
+        docstring = block_storage_tools.get_block_storage_volumes.__doc__
+
+        assert docstring is not None
+        assert "Get the list of Block Storage volumes" in docstring
+        assert "return" in docstring.lower() or "Return" in docstring
+        assert (
+            "list[Volume]" in docstring
+            or "A list of Volume objects" in docstring
+        )
+
+    def test_all_block_storage_methods_have_docstrings(self):
+        """Test that all public BlockStorageTools methods have proper docstrings."""
+        block_storage_tools = BlockStorageTools()
+
+        methods_to_check = [
+            "get_block_storage_volumes",
+            "get_volume_details",
+            "create_volume",
+            "delete_volume",
+            "extend_volume",
+        ]
+
+        for method_name in methods_to_check:
+            method = getattr(block_storage_tools, method_name)
+            docstring = method.__doc__
+            assert docstring is not None, (
+                f"{method_name} should have a docstring"
+            )
+            assert len(docstring.strip()) > 0, (
+                f"{method_name} docstring should not be empty"
+            )

--- a/tests/tools/test_block_storage_tools.py
+++ b/tests/tools/test_block_storage_tools.py
@@ -10,8 +10,8 @@ from unittest.mock import Mock
 class TestBlockStorageTools:
     """Test cases for BlockStorageTools class."""
 
-    def test_get_block_storage_volumes_success(self, mock_get_openstack_conn_block_storage):
-        """Test getting block storage volumes successfully."""
+    def test_get_volumes_success(self, mock_get_openstack_conn_block_storage):
+        """Test getting volumes successfully."""
         mock_conn = mock_get_openstack_conn_block_storage
 
         # Create mock volume objects
@@ -49,7 +49,7 @@ class TestBlockStorageTools:
 
         # Test BlockStorageTools
         block_storage_tools = BlockStorageTools()
-        result = block_storage_tools.get_block_storage_volumes()
+        result = block_storage_tools.get_volumes()
 
         # Verify results
         assert isinstance(result, list)
@@ -73,17 +73,17 @@ class TestBlockStorageTools:
         # Verify mock calls
         mock_conn.block_storage.volumes.assert_called_once()
 
-    def test_get_block_storage_volumes_empty_list(
+    def test_get_volumes_empty_list(
         self, mock_get_openstack_conn_block_storage
     ):
-        """Test getting block storage volumes when no volumes exist."""
+        """Test getting volumes when no volumes exist."""
         mock_conn = mock_get_openstack_conn_block_storage
 
         # Empty volume list
         mock_conn.block_storage.volumes.return_value = []
 
         block_storage_tools = BlockStorageTools()
-        result = block_storage_tools.get_block_storage_volumes()
+        result = block_storage_tools.get_volumes()
 
         # Verify empty list
         assert isinstance(result, list)
@@ -91,10 +91,10 @@ class TestBlockStorageTools:
 
         mock_conn.block_storage.volumes.assert_called_once()
 
-    def test_get_block_storage_volumes_single_volume(
+    def test_get_volumes_single_volume(
         self, mock_get_openstack_conn_block_storage
     ):
-        """Test getting block storage volumes with a single volume."""
+        """Test getting volumes with a single volume."""
         mock_conn = mock_get_openstack_conn_block_storage
 
         # Single volume
@@ -105,7 +105,7 @@ class TestBlockStorageTools:
         mock_volume.size = 5
         mock_volume.volume_type = None
         mock_volume.availability_zone = "nova"
-        mock_volume.created_at = None
+        mock_volume.created_at = "2024-01-01T12:00:00Z"
         mock_volume.is_bootable = False
         mock_volume.is_encrypted = False
         mock_volume.description = None
@@ -114,7 +114,7 @@ class TestBlockStorageTools:
         mock_conn.block_storage.volumes.return_value = [mock_volume]
 
         block_storage_tools = BlockStorageTools()
-        result = block_storage_tools.get_block_storage_volumes()
+        result = block_storage_tools.get_volumes()
 
         assert isinstance(result, list)
         assert len(result) == 1
@@ -124,7 +124,7 @@ class TestBlockStorageTools:
 
         mock_conn.block_storage.volumes.assert_called_once()
 
-    def test_get_block_storage_volumes_multiple_statuses(
+    def test_get_volumes_multiple_statuses(
         self, mock_get_openstack_conn_block_storage
     ):
         """Test volumes with various statuses."""
@@ -158,7 +158,7 @@ class TestBlockStorageTools:
         mock_conn.block_storage.volumes.return_value = mock_volumes
 
         block_storage_tools = BlockStorageTools()
-        result = block_storage_tools.get_block_storage_volumes()
+        result = block_storage_tools.get_volumes()
 
         # Verify result is a list with correct length
         assert isinstance(result, list)
@@ -174,7 +174,7 @@ class TestBlockStorageTools:
 
         mock_conn.block_storage.volumes.assert_called_once()
 
-    def test_get_block_storage_volumes_with_special_characters(
+    def test_get_volumes_with_special_characters(
         self, mock_get_openstack_conn_block_storage
     ):
         """Test volumes with special characters in names."""
@@ -213,7 +213,7 @@ class TestBlockStorageTools:
         ]
 
         block_storage_tools = BlockStorageTools()
-        result = block_storage_tools.get_block_storage_volumes()
+        result = block_storage_tools.get_volumes()
 
         assert isinstance(result, list)
         assert len(result) == 2
@@ -490,7 +490,7 @@ class TestBlockStorageTools:
         # Verify result is None
         assert result is None
         mock_conn.block_storage.delete_volume.assert_called_once_with(
-            "vol-delete", force=False
+            "vol-delete", force=False, ignore_missing=False
         )
 
     def test_delete_volume_force(self, mock_get_openstack_conn_block_storage):
@@ -510,7 +510,7 @@ class TestBlockStorageTools:
         assert result is None
 
         mock_conn.block_storage.delete_volume.assert_called_once_with(
-            "vol-force-delete", force=True
+            "vol-force-delete", force=True, ignore_missing=False
         )
 
     def test_delete_volume_error(self, mock_get_openstack_conn_block_storage):
@@ -582,7 +582,7 @@ class TestBlockStorageTools:
             call[0][0] for call in mock_tool_decorator.call_args_list
         ]
         expected_methods = [
-            block_storage_tools.get_block_storage_volumes,
+            block_storage_tools.get_volumes,
             block_storage_tools.get_volume_details,
             block_storage_tools.create_volume,
             block_storage_tools.delete_volume,
@@ -597,23 +597,23 @@ class TestBlockStorageTools:
         block_storage_tools = BlockStorageTools()
         assert block_storage_tools is not None
         assert hasattr(block_storage_tools, "register_tools")
-        assert hasattr(block_storage_tools, "get_block_storage_volumes")
+        assert hasattr(block_storage_tools, "get_volumes")
         assert hasattr(block_storage_tools, "get_volume_details")
         assert hasattr(block_storage_tools, "create_volume")
         assert hasattr(block_storage_tools, "delete_volume")
         assert hasattr(block_storage_tools, "extend_volume")
         # Verify all methods are callable
         assert callable(block_storage_tools.register_tools)
-        assert callable(block_storage_tools.get_block_storage_volumes)
+        assert callable(block_storage_tools.get_volumes)
         assert callable(block_storage_tools.get_volume_details)
         assert callable(block_storage_tools.create_volume)
         assert callable(block_storage_tools.delete_volume)
         assert callable(block_storage_tools.extend_volume)
 
-    def test_get_block_storage_volumes_docstring(self):
-        """Test that get_block_storage_volumes has proper docstring."""
+    def test_get_volumes_docstring(self):
+        """Test that get_volumes has proper docstring."""
         block_storage_tools = BlockStorageTools()
-        docstring = block_storage_tools.get_block_storage_volumes.__doc__
+        docstring = block_storage_tools.get_volumes.__doc__
 
         assert docstring is not None
         assert "Get the list of Block Storage volumes" in docstring
@@ -628,7 +628,7 @@ class TestBlockStorageTools:
         block_storage_tools = BlockStorageTools()
 
         methods_to_check = [
-            "get_block_storage_volumes",
+            "get_volumes",
             "get_volume_details",
             "create_volume",
             "delete_volume",


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of what this PR does -->
Replication of the other PR(https://github.com/openstack-kr/python-openstackmcp-server/pull/23)
I think that it would be better to create a new branch and megre with new PR like this rather than fixing the code version conflict caused by (https://github.com/openstack-kr/python-openstackmcp-server/issues/24) issue.

- Create CinderTools baseline code.
- Create CinderTools test baseline code.

## Key Changes
<!-- List the main changes made in this PR -->
- Add Cinder's basic tools(list, get details, create, delete, extend, attach, and detach Cinder volumes)

## Related Issues
<!-- Link to related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->
- #15 

## Additional context
This pull request adds support for managing OpenStack Cinder volumes via new tools and integrates them into the MCP server framework. The main changes include the introduction of a new `CinderTools` class with methods for common volume operations, registration of these tools in the main tool registry, and the addition of a corresponding test fixture for mocking Cinder connections.

**Cinder volume management integration:**

* Added new `CinderTools` class in `src/openstack_mcp_server/tools/cinder_tools.py` with methods to list, get details, create, delete, extend, attach, and detach Cinder volumes, all registered as MCP tools.
* Registered `CinderTools` within the main tool registry in `src/openstack_mcp_server/tools/__init__.py`, enabling its tools to be available through MCP.

**Testing support:**

* Added a pytest fixture `mock_get_openstack_conn_cinder` in `tests/conftest.py` to mock the OpenStack connection for Cinder tool unit tests.
<!-- Any additional information that reviewers should know -->