### PR TITLE
feat: create server

### DIFF
--- a/src/openstack_mcp_server/tools/response/compute.py
+++ b/src/openstack_mcp_server/tools/response/compute.py
@@ -1,9 +1,34 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class Flavor(BaseModel):
+    id: str | None = Field(default=None, exclude=True)
+    name: str = Field(validation_alias="original_name")
+    model_config = ConfigDict(validate_by_name=True)
+
+
+class Image(BaseModel):
+    id: str
+
+
+class ServerIp(BaseModel):
+    addr: str
+    version: int
+    type: str = Field(validation_alias="OS-EXT-IPS:type")
+
+    model_config = ConfigDict(validate_by_name=True)
+
+
+class ServerSecurityGroup(BaseModel):
+    name: str
 
 
 class Server(BaseModel):
-    """A model to represent a Compute server."""
-
-    name: str
     id: str
-    status: str
+    name: str
+    status: str | None = None
+    flavor: Flavor | None = None
+    image: Image | None = None
+    addresses: dict[str, list[ServerIp]] | None = None
+    key_name: str | None = None
+    security_groups: list[ServerSecurityGroup] | None = None


### PR DESCRIPTION
## Overview

This PR adds `create_server` functionality to the compute tools and updates/add schema for detailed server creation/retrieval.

## Key Changes
<!-- List the main changes made in this PR -->
- Add `create_server()` method to create new compute servers with parameters based on `openstacksdk`.
- Update Server model with additional fields: flavor, image, addresses, key_name, security_groups
- Add response classes: Flavor, Image, ServerIp, ServerSecurityGroup for proper data validation
- Update compute tools' name (get_compute_server -> get_server, and so on)

## Related Issues
<!-- Link to related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->
- #10 

## Additional context
<!-- Any additional information that reviewers should know -->
- Since `create_server` method in sdk gives insufficient data, I needed to fetch server again.
- Remove unnecessary test code about compute tools that does not check logic of tools.
