### PR TITLE
Fix: get_servers nullable field validation errors

### DIFF
--- a/src/openstack_mcp_server/tools/response/compute.py
+++ b/src/openstack_mcp_server/tools/response/compute.py
@@ -4,11 +4,14 @@ from pydantic import BaseModel, ConfigDict, Field
 class Server(BaseModel):
     class Flavor(BaseModel):
         id: str | None = Field(default=None, exclude=True)
-        name: str = Field(validation_alias="original_name")
+        name: str | None = Field(
+            default=None,
+            validation_alias="original_name",
+        )
         model_config = ConfigDict(validate_by_name=True)
 
     class Image(BaseModel):
-        id: str
+        id: str | None = Field(default=None)
 
     class IPAddress(BaseModel):
         addr: str


### PR DESCRIPTION
# Fix: get_servers nullable field validation errors

## Overview (한글)
OpenStack MCP 서버에서 `get_servers` 호출 시 발생하던 Pydantic 유효성 검증 오류를 수정했습니다. Server 모델의 Flavor와 Image 필드에서 nullable 값 처리가 누락되어 발생하던 문제를 해결했습니다.

## Key Changes (주요 변경사항)
- `Server.Flavor.name` 필드를 nullable로 변경 (`str | None`)
- `Server.Image.id` 필드를 nullable로 변경 (`str | None`) 및 기본값 설정
- OpenStack API 응답에서 누락될 수 있는 필드들에 대한 안전한 처리 추가

## Related Issues (관련 이슈)
다음 Pydantic 유효성 검증 오류 해결:
```
flavor.original_name Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
image.id Field required [type=missing, input_value={}, input_type=dict]
```

## Additional context (추가 정보)
OpenStack API에서 서버 정보를 조회할 때, 특정 상황에서 flavor의 `original_name`이나 image의 `id` 값이 `None`이거나 누락될 수 있습니다. 이는 서버가 삭제된 이미지나 flavor를 참조하거나, 임시적인 상태에 있을 때 발생할 수 있는 정상적인 케이스입니다. 이러한 경우를 안전하게 처리하기 위해 필드들을 nullable로 변경했습니다.

---

## Overview
Fixed Pydantic validation errors occurring when calling `get_servers` in the OpenStack MCP server. Resolved issues with missing nullable value handling in Server model's Flavor and Image fields.

## Key Changes
- Changed `Server.Flavor.name` field to nullable (`str | None`)
- Changed `Server.Image.id` field to nullable (`str | None`) with default value
- Added safe handling for fields that may be missing in OpenStack API responses

## Related Issues
Resolves the following Pydantic validation errors:
```
flavor.original_name Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
image.id Field required [type=missing, input_value={}, input_type=dict]
```

## Additional context
When querying server information from the OpenStack API, the `original_name` of a flavor or the `id` of an image can be `None` or missing in certain situations. This can occur when a server references a deleted image or flavor, or when it's in a transitional state. These are normal cases that should be handled gracefully, which is why the fields have been made nullable.

## Testing
- Verified that `get_servers` no longer throws validation errors
- Confirmed proper handling of servers with missing flavor/image information
- Tested backward compatibility with existing server data structures