### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+src/*/_version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template


### PR DESCRIPTION
## Overview
Add setuptools auto-generated _version.py files to .gitignore to prevent them from being tracked in version control.

## Key Changes
- Added `src/*/_version.py` pattern to .gitignore
- Prevents setuptools auto-generated version files from being committed

## Related Issues
- Relates to build pipeline optimization and preventing auto-generated file conflicts

## Additional context
The `_version.py` files are automatically generated by setuptools during the package build process in the release pipeline. These files should not be tracked in version control as they:
- Are build artifacts, not source code
- Can cause conflicts between local builds and CI/CD pipeline
- Are regenerated on each build with potentially different content
- Follow the same pattern as other build artifacts already ignored (*.egg-info/, build/, dist/)