### PR TITLE
fix: Fix incorrect attachment_id

### DIFF
--- a/src/openstack_mcp_server/tools/block_storage_tools.py
+++ b/src/openstack_mcp_server/tools/block_storage_tools.py
@@ -39,7 +39,7 @@ class BlockStorageTools:
                     VolumeAttachment(
                         server_id=attachment.get("server_id"),
                         device=attachment.get("device"),
-                        attachment_id=attachment.get("id"),
+                        attachment_id=attachment.get("attachment_id"),
                     ),
                 )
 
@@ -80,7 +80,7 @@ class BlockStorageTools:
                 VolumeAttachment(
                     server_id=attachment.get("server_id"),
                     device=attachment.get("device"),
-                    attachment_id=attachment.get("id"),
+                    attachment_id=attachment.get("attachment_id"),
                 ),
             )
 

--- a/tests/tools/test_block_storage_tools.py
+++ b/tests/tools/test_block_storage_tools.py
@@ -299,12 +299,12 @@ class TestBlockStorageTools:
             {
                 "server_id": "server-123",
                 "device": "/dev/vdb",
-                "id": "attach-1",
+                "attachment_id": "attach-1",
             },
             {
                 "server_id": "server-456",
                 "device": "/dev/vdc",
-                "id": "attach-2",
+                "attachment_id": "attach-2",
             },
         ]
 


### PR DESCRIPTION
## Overview
- The get_volume_details tool returns the same value for volume_id and attachment_id, but these should be different.

## Key Changes
<!-- List the main changes made in this PR -->
- Change attachments property name 'id' to attachment_id in volume

## Related Issues
<!-- Link to related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->
- #71 

## Additional context
<!-- Any additional information that reviewers should know -->