### PR TITLE
feat: Add delete image tool

### DIFF
--- a/src/openstack_mcp_server/tools/image_tools.py
+++ b/src/openstack_mcp_server/tools/image_tools.py
@@ -19,6 +19,7 @@ class ImageTools:
         mcp.tool()(self.get_image)
         mcp.tool()(self.get_images)
         mcp.tool()(self.create_image)
+        mcp.tool()(self.delete_image)
 
     def get_image(self, id: str) -> Image:
         """
@@ -121,3 +122,13 @@ class ImageTools:
 
         image = conn.get_image(created_image.id)
         return Image(**image)
+
+    def delete_image(self, image_id: str) -> None:
+        """
+        Delete an OpenStack image.
+
+        :param image_id: The ID of the image to delete.
+        :return: None
+        """
+        conn = get_openstack_conn()
+        conn.image.delete_image(image_id)

--- a/tests/tools/test_image_tools.py
+++ b/tests/tools/test_image_tools.py
@@ -297,3 +297,16 @@ class TestImageTools:
         assert mock_get_openstack_conn_image.get_image.called_once_with(
             mock_image["id"],
         )
+
+    def test_delete_image_success(self, mock_get_openstack_conn_image):
+        """Test deleting an image successfully."""
+        mock_conn = mock_get_openstack_conn_image
+        image_id = "img-delete-123-456"
+
+        mock_conn.image.delete_image.return_value = None
+
+        image_tools = ImageTools()
+        result = image_tools.delete_image(image_id)
+
+        assert result is None
+        mock_conn.image.delete_image.assert_called_once_with(image_id)


### PR DESCRIPTION
## Overview
Add delete-image tool in image service.

## Key Changes
- Add delete-image tool.
- Tests are updated and passing.

## Related Issues
- Relates to #20 

## Additional context
- Screenshot of the image delete behavior test
<img width="783" height="586" alt="image" src="https://github.com/user-attachments/assets/7842b35e-9389-421d-a716-3296f4858051" />

- Screenshot of image list for cleanup verification
<img width="421" height="749" alt="image" src="https://github.com/user-attachments/assets/64cc5d49-bf5e-439f-956a-13a0530efb24" />
