### PR TITLE
feat: Add network router CRUD tool

### DIFF
--- a/src/openstack_mcp_server/tools/network_tools.py
+++ b/src/openstack_mcp_server/tools/network_tools.py
@@ -1,10 +1,15 @@
 from fastmcp import FastMCP
 
 from .base import get_openstack_conn
+from .request.network import (
+    ExternalGatewayInfo,
+    Route,
+)
 from .response.network import (
     FloatingIP,
     Network,
     Port,
+    Router,
     Subnet,
 )
 
@@ -80,6 +85,7 @@ class NetworkTools:
         provider_network_type: str | None = None,
         provider_physical_network: str | None = None,
         provider_segmentation_id: int | None = None,
+        project_id: str | None = None,
     ) -> Network:
         """
         Create a new Network.
@@ -106,6 +112,9 @@ class NetworkTools:
 
         if provider_network_type:
             network_args["provider_network_type"] = provider_network_type
+
+        if project_id:
+            network_args["project_id"] = project_id
 
         if provider_physical_network:
             network_args["provider_physical_network"] = (
@@ -859,4 +868,177 @@ class NetworkTools:
             fixed_ip_address=openstack_ip.fixed_ip_address,
             port_id=openstack_ip.port_id,
             router_id=openstack_ip.router_id,
+        )
+
+    def get_routers(
+        self,
+        status_filter: str | None = None,
+        project_id: str | None = None,
+        is_admin_state_up: bool | None = None,
+    ) -> list[Router]:
+        """
+        Get the list of Routers with optional filtering.
+        :param status_filter: Filter by router status (e.g., `ACTIVE`, `DOWN`)
+        :param project_id: Filter by project ID
+        :param is_admin_state_up: Filter by admin state
+        :return: List of Router objects
+        """
+        conn = get_openstack_conn()
+        filters: dict = {}
+        if status_filter:
+            filters["status"] = status_filter.upper()
+        if project_id:
+            filters["project_id"] = project_id
+        if is_admin_state_up is not None:
+            filters["admin_state_up"] = is_admin_state_up
+        routers = conn.list_routers(filters=filters)
+        return [self._convert_to_router_model(r) for r in routers]
+
+    def create_router(
+        self,
+        name: str | None = None,
+        description: str | None = None,
+        is_admin_state_up: bool = True,
+        is_distributed: bool | None = None,
+        project_id: str | None = None,
+        external_gateway_info: ExternalGatewayInfo | None = None,
+    ) -> Router:
+        """
+        Create a new Router.
+        Typical use-cases:
+        - Create basic router: name="r1" (defaults to admin_state_up=True)
+        - Create distributed router: is_distributed=True
+        - Create with external gateway for north-south traffic:
+          external_gateway_info={"network_id": "ext-net", "enable_snat": True,
+          "external_fixed_ips": [{"subnet_id": "ext-subnet", "ip_address": "203.0.113.10"}]}
+        - Create with project ownership: project_id="proj-1"
+        Notes:
+        - external_gateway_info should follow Neutron schema: at minimum include
+          "network_id"; optional keys include "enable_snat" and "external_fixed_ips".
+        :param name: Router name
+        :param description: Router description
+        :param is_admin_state_up: Administrative state
+        :param is_distributed: Distributed router flag
+        :param project_id: Project ownership
+        :param external_gateway_info: External gateway info dict
+        :return: Created Router object
+        """
+        conn = get_openstack_conn()
+        router_args: dict = {"admin_state_up": is_admin_state_up}
+        if name is not None:
+            router_args["name"] = name
+        if description is not None:
+            router_args["description"] = description
+        if is_distributed is not None:
+            router_args["distributed"] = is_distributed
+        if project_id is not None:
+            router_args["project_id"] = project_id
+        if external_gateway_info is not None:
+            router_args["external_gateway_info"] = (
+                external_gateway_info.model_dump(exclude_none=True)
+            )
+        router = conn.network.create_router(**router_args)
+        return self._convert_to_router_model(router)
+
+    def get_router_detail(self, router_id: str) -> Router:
+        """
+        Get detailed information about a specific Router.
+        :param router_id: ID of the router to retrieve
+        :return: Router details
+        """
+        conn = get_openstack_conn()
+        router = conn.network.get_router(router_id)
+        return self._convert_to_router_model(router)
+
+    def update_router(
+        self,
+        router_id: str,
+        name: str | None = None,
+        description: str | None = None,
+        is_admin_state_up: bool | None = None,
+        is_distributed: bool | None = None,
+        external_gateway_info: ExternalGatewayInfo | None = None,
+        clear_external_gateway: bool = False,
+        routes: list[Route] | None = None,
+    ) -> Router:
+        """
+        Update Router attributes atomically. Only provided parameters are changed;
+        omitted parameters remain untouched.
+        Typical use-cases:
+        - Rename and change description: name="r-new", description="d".
+        - Toggle admin state: read current via get_router_detail(); pass inverted bool to is_admin_state_up.
+        - Set distributed flag: is_distributed=True or False.
+        - Set external gateway: external_gateway_info={"network_id": "ext-net", "enable_snat": True, "external_fixed_ips": [...]}.
+        - Clear external gateway: clear_external_gateway=True (takes precedence over external_gateway_info).
+        - Replace static routes: routes=[{"destination": "192.0.2.0/24", "nexthop": "10.0.0.1"}]. Pass [] to remove all routes.
+        Notes:
+        - For list-typed fields (routes), the provided list replaces the entire list on the server.
+        - To clear external gateway, use clear_external_gateway=True. If both provided, clear_external_gateway takes precedence.
+        :param router_id: ID of the router to update
+        :param name: New router name
+        :param description: New router description
+        :param is_admin_state_up: Administrative state
+        :param is_distributed: Distributed router flag
+        :param external_gateway_info: External gateway info dict to set
+        :param clear_external_gateway: If True, clear external gateway (set to None)
+        :param routes: Static routes (replaces entire list)
+        :return: Updated Router object
+        """
+        conn = get_openstack_conn()
+        update_args: dict = {}
+        if name is not None:
+            update_args["name"] = name
+        if description is not None:
+            update_args["description"] = description
+        if is_admin_state_up is not None:
+            update_args["admin_state_up"] = is_admin_state_up
+        if is_distributed is not None:
+            update_args["distributed"] = is_distributed
+        if clear_external_gateway:
+            update_args["external_gateway_info"] = None
+        elif external_gateway_info is not None:
+            update_args["external_gateway_info"] = (
+                external_gateway_info.model_dump(exclude_none=True)
+            )
+        if routes is not None:
+            update_args["routes"] = [
+                r.model_dump(exclude_none=True) for r in routes
+            ]
+        if not update_args:
+            current = conn.network.get_router(router_id)
+            return self._convert_to_router_model(current)
+        router = conn.network.update_router(router_id, **update_args)
+        return self._convert_to_router_model(router)
+
+    def delete_router(self, router_id: str) -> None:
+        """
+        Delete a Router.
+        :param router_id: ID of the router to delete
+        :return: None
+        """
+        conn = get_openstack_conn()
+        conn.network.delete_router(router_id, ignore_missing=False)
+        return None
+
+    def _convert_to_router_model(self, openstack_router) -> Router:
+        """
+        Convert an OpenStack Router object to a Router pydantic model.
+        :param openstack_router: OpenStack router object
+        :return: Pydantic Router model
+        """
+        return Router(
+            id=openstack_router.id,
+            name=getattr(openstack_router, "name", None),
+            status=getattr(openstack_router, "status", None),
+            description=getattr(openstack_router, "description", None),
+            project_id=getattr(openstack_router, "project_id", None),
+            is_admin_state_up=getattr(
+                openstack_router, "is_admin_state_up", None
+            ),
+            external_gateway_info=getattr(
+                openstack_router, "external_gateway_info", None
+            ),
+            is_distributed=getattr(openstack_router, "is_distributed", None),
+            is_ha=getattr(openstack_router, "is_ha", None),
+            routes=getattr(openstack_router, "routes", None),
         )

--- a/src/openstack_mcp_server/tools/network_tools.py
+++ b/src/openstack_mcp_server/tools/network_tools.py
@@ -73,22 +73,13 @@ class NetworkTools:
             filters["status"] = status_filter.upper()
 
         if shared_only:
-            filters["shared"] = True
+            filters["is_shared"] = True
 
-        server_filters = self._sanitize_server_filters(filters)
-        networks = conn.network.networks(**server_filters)
+        networks = conn.network.networks(**filters)
 
-        results = [
+        return [
             self._convert_to_network_model(network) for network in networks
         ]
-
-        if status_filter:
-            status_upper = status_filter.upper()
-            results = [
-                n for n in results if (n.status or "").upper() == status_upper
-            ]
-
-        return results
 
     def create_network(
         self,
@@ -464,16 +455,9 @@ class NetworkTools:
         if network_id:
             filters["network_id"] = network_id
 
-        server_filters = self._sanitize_server_filters(filters)
-        ports = conn.network.ports(**server_filters)
+        ports = conn.network.ports(**filters)
 
-        results = [self._convert_to_port_model(port) for port in ports]
-        if status_filter:
-            status_upper = status_filter.upper()
-            results = [
-                p for p in results if (p.status or "").upper() == status_upper
-            ]
-        return results
+        return [self._convert_to_port_model(port) for port in ports]
 
     def get_port_allowed_address_pairs(self, port_id: str) -> list[dict]:
         """

--- a/src/openstack_mcp_server/tools/network_tools.py
+++ b/src/openstack_mcp_server/tools/network_tools.py
@@ -47,6 +47,11 @@ class NetworkTools:
         mcp.tool()(self.update_floating_ip)
         mcp.tool()(self.create_floating_ips_bulk)
         mcp.tool()(self.assign_first_available_floating_ip)
+        mcp.tool()(self.get_routers)
+        mcp.tool()(self.create_router)
+        mcp.tool()(self.get_router_detail)
+        mcp.tool()(self.update_router)
+        mcp.tool()(self.delete_router)
 
     def get_networks(
         self,

--- a/src/openstack_mcp_server/tools/network_tools.py
+++ b/src/openstack_mcp_server/tools/network_tools.py
@@ -75,7 +75,7 @@ class NetworkTools:
         if shared_only:
             filters["shared"] = True
 
-        networks = conn.list_networks(filters=filters)
+        networks = conn.network.networks(**filters)
 
         return [
             self._convert_to_network_model(network) for network in networks
@@ -259,7 +259,7 @@ class NetworkTools:
             filters["project_id"] = project_id
         if is_dhcp_enabled is not None:
             filters["enable_dhcp"] = is_dhcp_enabled
-        subnets = conn.list_subnets(filters=filters)
+        subnets = conn.network.subnets(**filters)
         if has_gateway is not None:
             subnets = [
                 s for s in subnets if (s.gateway_ip is not None) == has_gateway
@@ -454,7 +454,7 @@ class NetworkTools:
             filters["device_id"] = device_id
         if network_id:
             filters["network_id"] = network_id
-        ports = conn.list_ports(filters=filters)
+        ports = conn.network.ports(**filters)
         return [self._convert_to_port_model(port) for port in ports]
 
     def get_port_allowed_address_pairs(self, port_id: str) -> list[dict]:
@@ -896,7 +896,7 @@ class NetworkTools:
             filters["project_id"] = project_id
         if is_admin_state_up is not None:
             filters["admin_state_up"] = is_admin_state_up
-        routers = conn.list_routers(filters=filters)
+        routers = conn.network.routers(**filters)
         return [self._convert_to_router_model(r) for r in routers]
 
     def create_router(

--- a/src/openstack_mcp_server/tools/request/network.py
+++ b/src/openstack_mcp_server/tools/request/network.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel
+
+
+class Route(BaseModel):
+    """Static route for a router."""
+
+    destination: str
+    nexthop: str
+
+
+class ExternalFixedIP(BaseModel):
+    """External fixed IP assignment for router gateway."""
+
+    subnet_id: str | None = None
+    ip_address: str | None = None
+
+
+class ExternalGatewayInfo(BaseModel):
+    """External gateway information for a router.
+    At minimum include `network_id`. Optionally include `enable_snat` and
+    `external_fixed_ips`.
+    """
+
+    network_id: str
+    enable_snat: bool | None = None
+    external_fixed_ips: list[ExternalFixedIP] | None = None

--- a/tests/tools/test_network_tools.py
+++ b/tests/tools/test_network_tools.py
@@ -54,7 +54,10 @@ class TestNetworkTools:
         mock_network2.provider_segmentation_id = None
         mock_network2.project_id = "proj-admin-000"
 
-        mock_conn.list_networks.return_value = [mock_network1, mock_network2]
+        mock_conn.network.networks.return_value = [
+            mock_network1,
+            mock_network2,
+        ]
 
         network_tools = self.get_network_tools()
         result = network_tools.get_networks()
@@ -91,7 +94,7 @@ class TestNetworkTools:
         assert result[0] == expected_network1
         assert result[1] == expected_network2
 
-        mock_conn.list_networks.assert_called_once_with(filters={})
+        mock_conn.network.networks.assert_called_once_with()
 
     def test_get_networks_empty_list(
         self,
@@ -100,14 +103,14 @@ class TestNetworkTools:
         """Test getting openstack networks when no networks exist."""
         mock_conn = mock_openstack_connect_network
 
-        mock_conn.list_networks.return_value = []
+        mock_conn.network.networks.return_value = []
 
         network_tools = self.get_network_tools()
         result = network_tools.get_networks()
 
         assert result == []
 
-        mock_conn.list_networks.assert_called_once_with(filters={})
+        mock_conn.network.networks.assert_called_once_with()
 
     def test_get_networks_with_status_filter(
         self,
@@ -142,7 +145,7 @@ class TestNetworkTools:
         mock_network2.provider_segmentation_id = None
         mock_network2.project_id = None
 
-        mock_conn.list_networks.return_value = [
+        mock_conn.network.networks.return_value = [
             mock_network1,
         ]  # Only ACTIVE network
         network_tools = self.get_network_tools()
@@ -152,8 +155,8 @@ class TestNetworkTools:
         assert result[0].id == "net-active"
         assert result[0].status == "ACTIVE"
 
-        mock_conn.list_networks.assert_called_once_with(
-            filters={"status": "ACTIVE"},
+        mock_conn.network.networks.assert_called_once_with(
+            status="ACTIVE",
         )
 
     def test_get_networks_shared_only(
@@ -189,7 +192,7 @@ class TestNetworkTools:
         mock_network2.provider_segmentation_id = None
         mock_network2.project_id = None
 
-        mock_conn.list_networks.return_value = [
+        mock_conn.network.networks.return_value = [
             mock_network2,
         ]  # Only shared network
 
@@ -200,8 +203,8 @@ class TestNetworkTools:
         assert result[0].id == "net-shared"
         assert result[0].is_shared is True
 
-        mock_conn.list_networks.assert_called_once_with(
-            filters={"shared": True},
+        mock_conn.network.networks.assert_called_once_with(
+            shared=True,
         )
 
     def test_create_network_success(self, mock_openstack_connect_network):
@@ -487,7 +490,7 @@ class TestNetworkTools:
         port.fixed_ips = [{"subnet_id": "subnet-1", "ip_address": "10.0.0.10"}]
         port.security_group_ids = ["sg-1", "sg-2"]
 
-        mock_conn.list_ports.return_value = [port]
+        mock_conn.network.ports.return_value = [port]
 
         tools = self.get_network_tools()
         result = tools.get_ports(
@@ -515,12 +518,10 @@ class TestNetworkTools:
             ),
         ]
 
-        mock_conn.list_ports.assert_called_once_with(
-            filters={
-                "status": "ACTIVE",
-                "device_id": "device-1",
-                "network_id": "net-1",
-            },
+        mock_conn.network.ports.assert_called_once_with(
+            status="ACTIVE",
+            device_id="device-1",
+            network_id="net-1",
         )
 
     def test_create_port_success(self, mock_openstack_connect_network):
@@ -848,7 +849,7 @@ class TestNetworkTools:
         subnet2.dns_nameservers = []
         subnet2.host_routes = []
 
-        mock_conn.list_subnets.return_value = [subnet1, subnet2]
+        mock_conn.network.subnets.return_value = [subnet1, subnet2]
 
         tools = self.get_network_tools()
         result = tools.get_subnets(
@@ -876,13 +877,11 @@ class TestNetworkTools:
             host_routes=[],
         )
 
-        mock_conn.list_subnets.assert_called_once_with(
-            filters={
-                "network_id": "net-1",
-                "ip_version": 4,
-                "project_id": "proj-1",
-                "enable_dhcp": True,
-            },
+        mock_conn.network.subnets.assert_called_once_with(
+            network_id="net-1",
+            ip_version=4,
+            project_id="proj-1",
+            enable_dhcp=True,
         )
 
     def test_get_subnets_has_gateway_false(
@@ -923,7 +922,7 @@ class TestNetworkTools:
         subnet2.dns_nameservers = []
         subnet2.host_routes = []
 
-        mock_conn.list_subnets.return_value = [subnet1, subnet2]
+        mock_conn.network.subnets.return_value = [subnet1, subnet2]
 
         tools = self.get_network_tools()
         result = tools.get_subnets(
@@ -1326,7 +1325,7 @@ class TestNetworkTools:
         r.is_ha = False
         r.routes = []
 
-        mock_conn.list_routers.return_value = [r]
+        mock_conn.network.routers.return_value = [r]
 
         tools = self.get_network_tools()
         res = tools.get_routers(
@@ -1350,12 +1349,10 @@ class TestNetworkTools:
             ),
         ]
 
-        mock_conn.list_routers.assert_called_once_with(
-            filters={
-                "status": "ACTIVE",
-                "project_id": "proj-1",
-                "admin_state_up": True,
-            },
+        mock_conn.network.routers.assert_called_once_with(
+            status="ACTIVE",
+            project_id="proj-1",
+            admin_state_up=True,
         )
 
     def test_create_router_success(self, mock_openstack_connect_network):

--- a/tests/tools/test_network_tools.py
+++ b/tests/tools/test_network_tools.py
@@ -155,9 +155,7 @@ class TestNetworkTools:
         assert result[0].id == "net-active"
         assert result[0].status == "ACTIVE"
 
-        mock_conn.network.networks.assert_called_once_with(
-            status="ACTIVE",
-        )
+        mock_conn.network.networks.assert_called_once_with()
 
     def test_get_networks_shared_only(
         self,
@@ -519,7 +517,6 @@ class TestNetworkTools:
         ]
 
         mock_conn.network.ports.assert_called_once_with(
-            status="ACTIVE",
             device_id="device-1",
             network_id="net-1",
         )
@@ -1350,7 +1347,6 @@ class TestNetworkTools:
         ]
 
         mock_conn.network.routers.assert_called_once_with(
-            status="ACTIVE",
             project_id="proj-1",
             admin_state_up=True,
         )


### PR DESCRIPTION
## Overview
- Add Router CRUD to Network tools

## Key Changes

> Router common tools

- Create router
- Get details router
- Get routers
- Update router
- Delete router

## Related Issues

- #60 


## Additional context
<img width="551" height="510" alt="스크린샷 2025-10-06 13 25 41" src="https://github.com/user-attachments/assets/b9386f15-108d-41b6-9e12-39b1827bee10" />

<img width="534" height="940" alt="스크린샷 2025-10-06 13 26 45" src="https://github.com/user-attachments/assets/1721a186-6f7d-432e-a7dd-4c106c0c908d" />

<img width="534" height="878" alt="스크린샷 2025-10-06 13 26 50" src="https://github.com/user-attachments/assets/00a78a4c-3db7-452f-b8c9-8be9b7fea718" />

<img width="531" height="191" alt="스크린샷 2025-10-06 13 26 54" src="https://github.com/user-attachments/assets/13552a1d-cb45-4742-aee9-cb23d6157e5e" />

> I have basic CRUD tests for the router. External gateway or DNS-related items will be handled as separate development tasks.