### PR TITLE
test: Remove unnecessary 'or []' fallback in assertions

### DIFF
--- a/tests/tools/test_network_tools.py
+++ b/tests/tools/test_network_tools.py
@@ -676,7 +676,7 @@ class TestNetworkTools:
         new_fixed = list(current.fixed_ips)
         new_fixed.append({"subnet_id": "subnet-2", "ip_address": "10.0.1.10"})
         res = tools.update_port("port-1", fixed_ips=new_fixed)
-        assert len(res.fixed_ips or []) == 2
+        assert len(res.fixed_ips) == 2
 
     def test_remove_port_fixed_ip(self, mock_openstack_connect_network):
         mock_conn = mock_openstack_connect_network
@@ -711,7 +711,7 @@ class TestNetworkTools:
             fi for fi in current.fixed_ips if fi["ip_address"] != "10.0.1.10"
         ]
         res = tools.update_port("port-1", fixed_ips=filtered)
-        assert len(res.fixed_ips or []) == 1
+        assert len(res.fixed_ips) == 1
 
     def test_get_and_update_allowed_address_pairs(
         self,
@@ -1289,6 +1289,7 @@ class TestNetworkTools:
         mock_conn.network.create_ip.side_effect = [f1]
         bulk = tools.create_floating_ips_bulk("ext-net", 1)
         assert len(bulk) == 1
+        assert bulk[0].id == f1.id
 
         exists = Mock()
         exists.id = "fip-b"


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of what this PR does -->
Improve test code quality by removing unnecessary defensive checks and adding explicit validations discovered during #77 investigation.

## Key Changes
<!-- List the main changes made in this PR -->
- Remove unnecessary `or []` fallback in `fixed_ips` assertions
  - `res.fixed_ips or []` → `res.fixed_ips` (fixed_ips is never None in test contexts)
  - Applied to `test_add_port_fixed_ip` and `test_remove_port_fixed_ip`
- Add explicit validation for bulk operation results
  - Add actual value validation to tests that only checked length
  - Added `assert bulk[0].id == f1.id` in `test_update_reassign_bulk_and_auto_assign_floating_ip`

## Related Issues
<!-- Link to related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->
- Relates to #77 (originally investigated `mock_mcp.tool.call_count` issues, but none were found)

## Additional context
<!-- Any additional information that reviewers should know -->
While investigating #77 for potential `call_count` test issues, no problems were found with that specific case. However, these code quality improvements were identified and addressed:
- The `or []` pattern was redundant since `fixed_ips` is always a list in these test scenarios
- The bulk operation test only checked length (`len(bulk) == 1`) without validating the actual returned object's ID, so added explicit value validation
---
## Overview
<!-- Provide a brief description of what this PR does -->
#77 조사 중 발견된 불필요한 방어 코드를 제거하고 명시적인 검증을 추가하여 테스트 코드 품질을 개선합니다.

## Key Changes
<!-- List the main changes made in this PR -->
- `fixed_ips` assertion에서 불필요한 `or []` 폴백 제거
  - `res.fixed_ips or []` → `res.fixed_ips` (테스트 컨텍스트에서 fixed_ips는 절대 None이 아님)
  - `test_add_port_fixed_ip`와 `test_remove_port_fixed_ip`에 적용
- bulk 작업 결과에 대한 명시적 검증 추가
  - 길이 검사만 하던 테스트에 실제 값 검증 추가
  - `test_update_reassign_bulk_and_auto_assign_floating_ip`에 `assert bulk[0].id == f1.id` 추가

## Related Issues
<!-- Link to related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->
- Relates to #77 (원래 `mock_mcp.tool.call_count` 문제를 조사했으나 발견되지 않음)

## Additional context
<!-- Any additional information that reviewers should know -->
#77의 `call_count` 테스트 문제를 조사하는 과정에서 해당 케이스의 문제는 발견되지 않았으나, 다음과 같은 코드 품질 개선 사항을 발견하여 수정했습니다:
- `or []` 패턴은 테스트 시나리오에서 `fixed_ips`가 항상 리스트이므로 불필요함
- bulk 작업 테스트에서 길이 검사(`len(bulk) == 1`)만 하고 있어, 반환된 객체의 실제 값(ID)에 대한 검증을 추가함