### PR TITLE
feat: connection manager related tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,6 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+# Openstack Config Files
+clouds.yaml

--- a/src/openstack_mcp_server/tools/__init__.py
+++ b/src/openstack_mcp_server/tools/__init__.py
@@ -1,5 +1,7 @@
 from fastmcp import FastMCP
 
+from openstack_mcp_server.tools.connection import ConnectionManager
+
 
 def register_tool(mcp: FastMCP):
     """
@@ -17,3 +19,4 @@ def register_tool(mcp: FastMCP):
     IdentityTools().register_tools(mcp)
     NetworkTools().register_tools(mcp)
     BlockStorageTools().register_tools(mcp)
+    ConnectionManager().register_tools(mcp)

--- a/src/openstack_mcp_server/tools/base.py
+++ b/src/openstack_mcp_server/tools/base.py
@@ -1,7 +1,12 @@
+import openstack
+
+from openstack_mcp_server import config
 from openstack_mcp_server.tools.connection import ConnectionManager
 
 
 _connection_manager = ConnectionManager()
+
+openstack.enable_logging(debug=config.MCP_DEBUG_MODE)
 
 
 def get_openstack_conn():

--- a/src/openstack_mcp_server/tools/base.py
+++ b/src/openstack_mcp_server/tools/base.py
@@ -1,27 +1,16 @@
-import openstack
-
-from openstack import connection
-
-from openstack_mcp_server import config
+from openstack_mcp_server.tools.connection import ConnectionManager
 
 
-class OpenStackConnectionManager:
-    """OpenStack Connection Manager"""
-
-    _connection: connection.Connection | None = None
-
-    @classmethod
-    def get_connection(cls) -> connection.Connection:
-        """OpenStack Connection"""
-        if cls._connection is None:
-            openstack.enable_logging(debug=config.MCP_DEBUG_MODE)
-            cls._connection = openstack.connect(cloud=config.MCP_CLOUD_NAME)
-        return cls._connection
-
-
-_openstack_connection_manager = OpenStackConnectionManager()
+_connection_manager = ConnectionManager()
 
 
 def get_openstack_conn():
-    """Get OpenStack Connection"""
-    return _openstack_connection_manager.get_connection()
+    return _connection_manager.get_connection()
+
+
+def set_openstack_cloud_name(cloud_name: str) -> None:
+    _connection_manager.set_cloud_name(cloud_name)
+
+
+def get_openstack_cloud_name() -> str:
+    return _connection_manager.get_cloud_name()

--- a/src/openstack_mcp_server/tools/connection.py
+++ b/src/openstack_mcp_server/tools/connection.py
@@ -10,9 +10,6 @@ from openstack_mcp_server import config
 class ConnectionManager:
     _cloud_name = config.MCP_CLOUD_NAME
 
-    def __init__(self):
-        openstack.enable_logging(debug=config.MCP_DEBUG_MODE)
-
     def register_tools(self, mcp: FastMCP):
         mcp.tool(self.get_cloud_config)
         mcp.tool(self.get_cloud_names)

--- a/src/openstack_mcp_server/tools/connection.py
+++ b/src/openstack_mcp_server/tools/connection.py
@@ -1,0 +1,73 @@
+import openstack
+
+from fastmcp import FastMCP
+from openstack import connection
+from openstack.config.loader import OpenStackConfig
+
+from openstack_mcp_server import config
+
+
+class ConnectionManager:
+    _cloud_name = config.MCP_CLOUD_NAME
+
+    def __init__(self):
+        openstack.enable_logging(debug=config.MCP_DEBUG_MODE)
+
+    def register_tools(self, mcp: FastMCP):
+        mcp.tool(self.get_cloud_config)
+        mcp.tool(self.get_cloud_names)
+        mcp.tool(self.get_cloud_name)
+        mcp.tool(self.set_cloud_name)
+
+    def get_connection(self) -> connection.Connection:
+        return openstack.connect(cloud=self._cloud_name)
+
+    def get_cloud_names(self) -> list[str]:
+        """List available cloud configurations.
+
+        :return: Names of OpenStack clouds from user's config file.
+        """
+        config = OpenStackConfig()
+        return list(config.get_cloud_names())
+
+    def get_cloud_config(self) -> dict:
+        """Provide cloud configuration with secrets masked of current user's config file.
+
+        :return: Cloud configuration dictionary with credentials masked.
+        """
+        config = OpenStackConfig()
+        return ConnectionManager._mask_credential(
+            config.cloud_config, ["password"]
+        )
+
+    @staticmethod
+    def _mask_credential(
+        config_dict: dict, credential_keys: list[str]
+    ) -> dict:
+        masked = {}
+        for k, v in config_dict.items():
+            if k in credential_keys:
+                masked[k] = "****"
+            elif isinstance(v, dict):
+                masked[k] = ConnectionManager._mask_credential(
+                    v, credential_keys
+                )
+            else:
+                masked[k] = v
+        return masked
+
+    @classmethod
+    def get_cloud_name(cls) -> str:
+        """Return the currently selected cloud name.
+
+        :return: current OpenStack cloud name.
+        """
+        return cls._cloud_name
+
+    @classmethod
+    def set_cloud_name(cls, cloud_name: str) -> None:
+        """Set cloud name to use for later connections. Must set name from currently valid cloud config file.
+
+        :param cloud_name: Name of the OpenStack cloud profile to activate.
+        """
+        cls._cloud_name = cloud_name


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of what this PR does -->
권한 및 오픈스택 환경을 변경하며 interaction할 수 있도록 ConnectionManager 관련 tool를 추가

## Key Changes
<!-- List the main changes made in this PR -->
- `tools/connection.py` 생성하여 cloud를 선택하고 조회할 수 있는 툴 추가
  - 권한이 부족하거나 다른 환경도 옮기면서 실행할 수 있다

## Related Issues
<!-- Link to related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->
- https://github.com/openstack-kr/python-openstackmcp-server/issues/89

## Additional context

실행 화면 예시
<img width="628" height="641" alt="image" src="https://github.com/user-attachments/assets/f52ca621-3c5c-4bdf-8d43-a1d551fe4a23" />

<!-- Any additional information that reviewers should know -->
처음 [issue](https://github.com/openstack-kr/python-openstackmcp-server/issues/89)에서는 config 정보를 resource로 제공하려고 했는데요. 아래 이유로 인해 tool로 제공하고자 하는데, 편하게 의견 주세요.

resource는 사용자가 직접 추가해야하는데, 현재 경우에 적합하지 않다고 생각하였습니다.
<img width="761" height="388" alt="image" src="https://github.com/user-attachments/assets/82d38999-3923-4f7a-8bc8-f21740488399" />
활성화 여부만 체크하면 되는 tool과 달리 사진처럼 resource는 가져와서 대화에 포함시켜야하는데, **사용자가 의도적으로 포함시켜서 질의하는 상황에 적합**하다고 판단됩니다. 이 기능은 권한 오류 등이 발생할 때, llm이 function calling으로 get config -> set config를 수행하는 것을 의도하므로 암묵적으로 포함되어야 합니다. 현재로는 사용자가 mcp tool 호출시 오류를 겪을 때 오류 내용 기반으로 질문하기 위한 openstack sdk 호출 "로그 파일" 정도가 resource에 적합하다고 생각이 듭니다.
