### PR TITLE
bug: Delete is_bootable attribute

### DIFF
--- a/src/openstack_mcp_server/tools/block_storage_tools.py
+++ b/src/openstack_mcp_server/tools/block_storage_tools.py
@@ -110,7 +110,6 @@ class BlockStorageTools:
         description: str | None = None,
         volume_type: str | None = None,
         availability_zone: str | None = None,
-        bootable: bool | None = None,
         image: str | None = None,
     ) -> Volume:
         """
@@ -121,7 +120,6 @@ class BlockStorageTools:
         :param description: Optional description for the volume
         :param volume_type: Optional volume type
         :param availability_zone: Optional availability zone
-        :param bootable: Optional flag to make the volume bootable
         :param image: Optional Image name, ID or object from which to create
         :return: The created Volume object
         """
@@ -141,7 +139,6 @@ class BlockStorageTools:
         volume = conn.block_storage.create_volume(
             size=size,
             image=image,
-            bootable=bootable,
             **volume_kwargs,
         )
 

--- a/tests/tools/test_block_storage_tools.py
+++ b/tests/tools/test_block_storage_tools.py
@@ -395,7 +395,6 @@ class TestBlockStorageTools:
         mock_conn.block_storage.create_volume.assert_called_once_with(
             size=10,
             image=None,
-            bootable=None,
             name="new-volume",
             description="Test volume",
             volume_type="ssd",
@@ -435,7 +434,6 @@ class TestBlockStorageTools:
         mock_conn.block_storage.create_volume.assert_called_once_with(
             size=5,
             image=None,
-            bootable=None,
             name="minimal-volume",
         )
 
@@ -468,7 +466,6 @@ class TestBlockStorageTools:
             "Bootable volume from image",
             "ssd",
             "nova",
-            True,
             "ubuntu-20.04",
         )
 
@@ -476,12 +473,10 @@ class TestBlockStorageTools:
         assert result.name == "bootable-volume"
         assert result.id == "vol-bootable"
         assert result.size == 20
-        assert result.is_bootable
 
         mock_conn.block_storage.create_volume.assert_called_once_with(
             size=20,
             image="ubuntu-20.04",
-            bootable=True,
             name="bootable-volume",
             description="Bootable volume from image",
             volume_type="ssd",


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of what this PR does -->
- Delete bootable attribute

## Key Changes
<!-- List the main changes made in this PR -->
- Delete bootable attribute in `create_volume`.
- Tests are updated and passing

## Related Issues
<!-- Link to related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->
-  #93 

## Additional context
<!-- Any additional information that reviewers should know -->
<img width="820" height="511" alt="image" src="https://github.com/user-attachments/assets/3c60f779-f92a-4d28-87b5-f7e77570750d" />
