### PR TITLE
feat(identity): Add name filter in get_projects tool

### DIFF
--- a/src/openstack_mcp_server/tools/identity_tools.py
+++ b/src/openstack_mcp_server/tools/identity_tools.py
@@ -227,16 +227,23 @@ class IdentityTools:
             is_enabled=updated_domain.is_enabled,
         )
 
-    def get_projects(self) -> list[Project]:
+    def get_projects(self, name: str | None = None) -> list[Project]:
         """
         Get the list of Identity projects.
+
+        :param name: The name of the project.
+            It is used to get a project_id from a project name.
 
         :return: A list of Project objects representing the projects.
         """
         conn = get_openstack_conn()
 
+        filters = {}
+        if name:
+            filters["name"] = name
+
         project_list = []
-        for project in conn.identity.projects():
+        for project in conn.identity.projects(**filters):
             project_list.append(
                 Project(
                     id=project.id,

--- a/tests/tools/test_identity_tools.py
+++ b/tests/tools/test_identity_tools.py
@@ -774,6 +774,40 @@ class TestIdentityTools:
         # Verify mock calls
         mock_conn.identity.projects.assert_called_once()
 
+    def test_get_projects_with_name(self, mock_get_openstack_conn_identity):
+        """Test getting identity projects with a name."""
+        mock_conn = mock_get_openstack_conn_identity
+
+        # Create mock project objects
+        mock_project1 = Mock()
+        mock_project1.id = "project1111111111111111111111111"
+        mock_project1.name = "ProjectOne"
+        mock_project1.description = "Project One description"
+        mock_project1.is_enabled = True
+        mock_project1.domain_id = "domain1111111111111111111111111"
+        mock_project1.parent_id = "parentproject1111111111111111111"
+
+        mock_conn.identity.projects.return_value = [mock_project1]
+
+        # Test get_projects()
+        identity_tools = self.get_identity_tools()
+        result = identity_tools.get_projects(name="ProjectOne")
+
+        # Verify results
+        assert result[0] == Project(
+            id="project1111111111111111111111111",
+            name="ProjectOne",
+            description="Project One description",
+            is_enabled=True,
+            domain_id="domain1111111111111111111111111",
+            parent_id="parentproject1111111111111111111",
+        )
+
+        # Verify mock calls
+        mock_conn.identity.projects.assert_called_once_with(
+            name="ProjectOne",
+        )
+
     def test_get_projects_empty_list(self, mock_get_openstack_conn_identity):
         """Test getting identity projects when there are no projects."""
         mock_conn = mock_get_openstack_conn_identity


### PR DESCRIPTION
## Overview
<!-- Provide a brief description of what this PR does -->
- To get project_id from project_name, l add the `name` attribute in `get_projects` tool. 

## Key Changes
<!-- List the main changes made in this PR -->
- Add name attribute in get_projects.
- Tests are updated and passing.

## Related Issues
<!-- Link to related issues using "Fixes #123", "Closes #456", or "Relates to #789" -->
- closed #95 

## Additional context
- x