### PR TITLE
refactor: Remove deprecated SSE transport option

### DIFF
--- a/src/openstack_mcp_server/__init__.py
+++ b/src/openstack_mcp_server/__init__.py
@@ -35,7 +35,7 @@ def main():
         signal.signal(signal.SIGTERM, handle_interrupt)
 
         # Validate transport protocol
-        if MCP_TRANSPORT not in ["stdio", "sse", "streamable-http"]:
+        if MCP_TRANSPORT not in ["stdio", "streamable-http"]:
             logger.error(
                 f"Invalid transport protocol: {MCP_TRANSPORT}. Using stdio instead.",
             )

--- a/src/openstack_mcp_server/server.py
+++ b/src/openstack_mcp_server/server.py
@@ -23,7 +23,5 @@ def serve(transport: str, **kwargs):
         mcp.run(transport="stdio", **kwargs)
     elif transport == "streamable-http":
         mcp.run(transport="streamable-http", **kwargs)
-    elif transport == "sse":
-        mcp.run(transport="sse", **kwargs)
     else:
         raise ValueError(f"Unsupported transport: {transport}")


### PR DESCRIPTION
refactor: Remove deprecated SSE transport option

## Overview
- Remove SSE(deprecated) transport support from MCP Server

## Key Changes
- Remove SSE transport handling in server.py and __init__.py

## Related Issues
- Closes #97 

## Additional context
- None